### PR TITLE
fix: embed gemspec files in VFS for runtime Bundler support

### DIFF
--- a/lib/kompo/tasks/copy_gemfile.rb
+++ b/lib/kompo/tasks/copy_gemfile.rb
@@ -5,7 +5,7 @@ require 'fileutils'
 module Kompo
   # Copy Gemfile, Gemfile.lock, and gemspec files to working directory if they exist
   class CopyGemfile < Taski::Task
-    exports :gemfile_exists
+    exports :gemfile_exists, :gemspec_paths
 
     def run
       work_dir = WorkDir.path
@@ -15,7 +15,7 @@ module Kompo
       gemfile_lock_path = File.join(project_dir, 'Gemfile.lock')
 
       @gemfile_exists = File.exist?(gemfile_path)
-      @copied_gemspecs = []
+      @gemspec_paths = []
 
       if @gemfile_exists
         FileUtils.cp(gemfile_path, work_dir)
@@ -46,7 +46,7 @@ module Kompo
       FileUtils.rm_f(gemfile_lock)
 
       # Clean up copied gemspec files
-      (@copied_gemspecs || []).each do |gemspec|
+      (@gemspec_paths || []).each do |gemspec|
         FileUtils.rm_f(gemspec)
       end
 
@@ -66,7 +66,7 @@ module Kompo
       gemspec_files.each do |gemspec_path|
         dest_path = File.join(work_dir, File.basename(gemspec_path))
         FileUtils.cp(gemspec_path, dest_path)
-        @copied_gemspecs << dest_path
+        @gemspec_paths << dest_path
         puts "Copied: #{File.basename(gemspec_path)}"
       end
 

--- a/lib/kompo/tasks/make_fs_c.rb
+++ b/lib/kompo/tasks/make_fs_c.rb
@@ -94,11 +94,14 @@ module Kompo
       paths << CopyProjectFiles.entrypoint_path
       paths += CopyProjectFiles.additional_paths
 
-      # 2. Gemfile and Gemfile.lock (if exists)
+      # 2. Gemfile, Gemfile.lock, and gemspec files (if exists)
       #    Created by: CopyGemfile
       if CopyGemfile.gemfile_exists
         paths << File.join(@work_dir, 'Gemfile')
         paths << File.join(@work_dir, 'Gemfile.lock')
+
+        # Include gemspec files for Bundler's gemspec directive
+        paths += CopyGemfile.gemspec_paths
 
         # 3. Bundle directory (.bundle/config and bundle/ruby/X.Y.Z/gems/...)
         #    Created by: BundleInstall

--- a/test/tasks/make_c_test.rb
+++ b/test/tasks/make_c_test.rb
@@ -286,6 +286,7 @@ class MakeFsCTest < Minitest::Test
   def mock_fs_c_dependencies(work_dir, tmpdir, entrypoint,
                              additional_paths: [],
                              gemfile_exists: false,
+                             gemspec_paths: [],
                              bundler_config_path: nil,
                              bundle_ruby_dir: nil)
     mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
@@ -294,7 +295,7 @@ class MakeFsCTest < Minitest::Test
               original_ruby_install_dir: '/path/to/install',
               ruby_major_minor: '3.4')
     mock_task(Kompo::CopyProjectFiles, entrypoint_path: entrypoint, additional_paths: additional_paths)
-    mock_task(Kompo::CopyGemfile, gemfile_exists: gemfile_exists)
+    mock_task(Kompo::CopyGemfile, gemfile_exists: gemfile_exists, gemspec_paths: gemspec_paths)
     mock_task(Kompo::BundleInstall, bundler_config_path: bundler_config_path, bundle_ruby_dir: bundle_ruby_dir)
     mock_task(Kompo::CheckStdlibs, paths: [])
   end


### PR DESCRIPTION
## Summary
- Export `gemspec_paths` from `CopyGemfile` task
- Include gemspec files in VFS via `MakeFsC`'s `collect_embed_paths`
- This allows Bundler to find gemspec at runtime when Gemfile uses `gemspec` directive

Fixes runtime error: `There are no gemspecs at ...`

## Test plan
- [x] All existing tests pass
- [x] Updated mock helper with `gemspec_paths` parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced dependency embedding to include gemspec files alongside existing Gemfiles and Gemfile.lock files, providing more complete support for Ruby projects with multiple dependency specifications and complex packaging requirements.

* **Tests**
  * Expanded test utilities and mocking framework to validate gemspec file path handling and ensure proper integration with dependency management workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->