### PR TITLE
Add --no-gemfile option to skip Gemfile processing

### DIFF
--- a/exe/kompo
+++ b/exe/kompo
@@ -18,6 +18,7 @@ opt = OptionParser.new do |o|
   end
   o.on('--no-cache', 'Build Ruby from source, ignoring cache') { |_v| args[:no_cache] = true }
   o.on('--no-stdlib', 'Exclude Ruby standard library from binary') { |_v| args[:no_stdlib] = true }
+  o.on('--no-gemfile', 'Skip Gemfile processing (no bundle install)') { |_v| args[:no_gemfile] = true }
   o.on('--local-vfs-path=PATH', 'Path to local kompo-vfs for development') do |v|
     args[:local_kompo_vfs_path] = File.expand_path(v)
   end

--- a/lib/kompo/tasks/copy_gemfile.rb
+++ b/lib/kompo/tasks/copy_gemfile.rb
@@ -11,6 +11,14 @@ module Kompo
       work_dir = WorkDir.path
       project_dir = Taski.args.fetch(:project_dir, Taski.env.working_directory) || Taski.env.working_directory
 
+      # Skip Gemfile processing if --no-gemfile is specified
+      if Taski.args[:no_gemfile]
+        puts 'Skipping Gemfile (--no-gemfile specified)'
+        @gemfile_exists = false
+        @gemspec_paths = []
+        return
+      end
+
       gemfile_path = File.join(project_dir, 'Gemfile')
       gemfile_lock_path = File.join(project_dir, 'Gemfile.lock')
 

--- a/test/tasks/copy_files_test.rb
+++ b/test/tasks/copy_files_test.rb
@@ -113,6 +113,24 @@ class CopyGemfileTest < Minitest::Test
       assert File.exist?(File.join(work_dir, 'other_gem.gemspec'))
     end
   end
+
+  def test_copy_gemfile_skips_when_no_gemfile_option_specified
+    Dir.mktmpdir do |tmpdir|
+      work_dir = File.join(tmpdir, 'work')
+      project_dir = File.join(tmpdir, 'project')
+      FileUtils.mkdir_p([work_dir, project_dir])
+      # Create Gemfile in project_dir
+      File.write(File.join(project_dir, 'Gemfile'), "source 'https://rubygems.org'")
+
+      mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
+      mock_args(project_dir: project_dir, no_gemfile: true)
+
+      # gemfile_exists should be false even though Gemfile exists
+      refute Kompo::CopyGemfile.gemfile_exists
+      # Verify Gemfile was NOT copied to work_dir
+      refute File.exist?(File.join(work_dir, 'Gemfile'))
+    end
+  end
 end
 
 class CopyProjectFilesTest < Minitest::Test


### PR DESCRIPTION
## Summary
- Add `--no-gemfile` CLI option to skip Gemfile processing
- When specified, Gemfile is not copied and bundle install is skipped
- User gem native extensions are also skipped (bundled gems from Ruby 4.0+ still work)

## Use case
Useful for projects that don't use Bundler or want to package only with Ruby's bundled gems.

## Test plan
- [x] Added test for `--no-gemfile` option in CopyGemfileTest
- [x] All existing tests pass (151 tests, 437 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)