### PR TITLE
Add standardrb lint check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,34 @@ on:
     branches: [master]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+
+      - name: Run standardrb
+        run: bundle exec standardrb
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rake test
+
   build:
     strategy:
       fail-fast: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in kompo.gemspec
 gemspec
 
-gem 'rake', '~> 13.0'
-gem 'taski', '~> 0.8.0'
+gem "rake", "~> 13.0"
+gem "taski", "~> 0.8.0"
 
 group :development, :test do
-  gem 'debug'
-  gem 'minitest'
-  gem 'simplecov', require: false
-  gem 'standard'
+  gem "debug"
+  gem "minitest"
+  gem "simplecov", require: false
+  gem "standard"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require 'bundler/gem_tasks'
-require 'rake/testtask'
+require "bundler/gem_tasks"
+require "rake/testtask"
 
 Rake::TestTask.new(:test) do |t|
-  t.libs << 'test'
-  t.libs << 'lib'
-  t.test_files = FileList['test/**/*_test.rb']
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/**/*_test.rb"]
 end
 
-require 'standard/rake'
+require "standard/rake"
 
 task default: %i[test standard]

--- a/exe/kompo
+++ b/exe/kompo
@@ -1,46 +1,46 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'optparse'
-require_relative '../lib/kompo'
+require "optparse"
+require_relative "../lib/kompo"
 
 args = {}
 opt = OptionParser.new do |o|
-  o.banner = 'Usage: kompo [options] [files...]'
-  o.separator ''
-  o.separator 'Options:'
+  o.banner = "Usage: kompo [options] [files...]"
+  o.separator ""
+  o.separator "Options:"
 
-  o.on('-e', '--entrypoint=FILE', 'Entry point file (default: main.rb)') { |v| args[:entrypoint] = v }
-  o.on('-o', '--output=DIR', 'Output directory for the binary') { |v| args[:output_dir] = File.expand_path(v) }
-  o.on('--ruby-version=VERSION', "Ruby version to use (default: #{RUBY_VERSION})") { |v| args[:ruby_version] = v }
-  o.on('--ruby-source=PATH', 'Path to Ruby source tarball or directory') do |v|
+  o.on("-e", "--entrypoint=FILE", "Entry point file (default: main.rb)") { |v| args[:entrypoint] = v }
+  o.on("-o", "--output=DIR", "Output directory for the binary") { |v| args[:output_dir] = File.expand_path(v) }
+  o.on("--ruby-version=VERSION", "Ruby version to use (default: #{RUBY_VERSION})") { |v| args[:ruby_version] = v }
+  o.on("--ruby-source=PATH", "Path to Ruby source tarball or directory") do |v|
     args[:ruby_source_path] = File.expand_path(v)
   end
-  o.on('--no-cache', 'Build Ruby from source, ignoring cache') { |_v| args[:no_cache] = true }
-  o.on('--no-stdlib', 'Exclude Ruby standard library from binary') { |_v| args[:no_stdlib] = true }
-  o.on('--no-gemfile', 'Skip Gemfile processing (no bundle install)') { |_v| args[:no_gemfile] = true }
-  o.on('--local-vfs-path=PATH', 'Path to local kompo-vfs for development') do |v|
+  o.on("--no-cache", "Build Ruby from source, ignoring cache") { |_v| args[:no_cache] = true }
+  o.on("--no-stdlib", "Exclude Ruby standard library from binary") { |_v| args[:no_stdlib] = true }
+  o.on("--no-gemfile", "Skip Gemfile processing (no bundle install)") { |_v| args[:no_gemfile] = true }
+  o.on("--local-vfs-path=PATH", "Path to local kompo-vfs for development") do |v|
     args[:local_kompo_vfs_path] = File.expand_path(v)
   end
-  o.on('--clean[=VERSION]', 'Clean cache (current Ruby version by default, or specify VERSION, or "all")') do |v|
+  o.on("--clean[=VERSION]", 'Clean cache (current Ruby version by default, or specify VERSION, or "all")') do |v|
     args[:clean_cache] = v.nil? ? RUBY_VERSION : v
   end
-  o.on('-t', '--tree', 'Show task dependency tree and exit') do
+  o.on("-t", "--tree", "Show task dependency tree and exit") do
     puts Kompo::Packing.tree
     exit(0)
   end
-  o.on('-v', '--version', 'Show version') do
+  o.on("-v", "--version", "Show version") do
     puts "kompo #{Kompo::VERSION}"
     exit(0)
   end
-  o.on('-h', '--help', 'Show this help message') do
+  o.on("-h", "--help", "Show this help message") do
     puts o
     exit(0)
   end
 
-  o.separator ''
-  o.separator 'Files:'
-  o.separator '  Additional files and directories to include in the binary'
+  o.separator ""
+  o.separator "Files:"
+  o.separator "  Additional files and directories to include in the binary"
 end
 opt.parse!(ARGV)
 args[:files] = ARGV

--- a/kompo.gemspec
+++ b/kompo.gemspec
@@ -1,22 +1,22 @@
 # frozen_string_literal: true
 
-require_relative 'lib/kompo/version'
+require_relative "lib/kompo/version"
 
 Gem::Specification.new do |spec|
-  spec.name = 'kompo'
+  spec.name = "kompo"
   spec.version = Kompo::VERSION
-  spec.authors = ['Sho Hirano']
-  spec.email = ['ahogappa@gmail.com']
+  spec.authors = ["Sho Hirano"]
+  spec.email = ["ahogappa@gmail.com"]
 
-  spec.summary = 'A tool to pack Ruby and Ruby scripts in one binary.'
-  spec.description = 'A tool to pack Ruby and Ruby scripts in one binary. This tool is still under development.'
-  spec.homepage = 'https://github.com/ahogappa0613/kompo'
-  spec.required_ruby_version = '>= 3.1.0'
-  spec.required_rubygems_version = '>= 3.3.11'
+  spec.summary = "A tool to pack Ruby and Ruby scripts in one binary."
+  spec.description = "A tool to pack Ruby and Ruby scripts in one binary. This tool is still under development."
+  spec.homepage = "https://github.com/ahogappa0613/kompo"
+  spec.required_ruby_version = ">= 3.1.0"
+  spec.required_rubygems_version = ">= 3.3.11"
 
-  spec.metadata['homepage_uri'] = spec.homepage
-  spec.metadata['source_code_uri'] = 'https://github.com/ahogappa0613/kompo'
-  spec.metadata['changelog_uri'] = 'https://github.com/ahogappa0613/kompo'
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = "https://github.com/ahogappa0613/kompo"
+  spec.metadata["changelog_uri"] = "https://github.com/ahogappa0613/kompo"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
@@ -25,15 +25,15 @@ Gem::Specification.new do |spec|
       (File.expand_path(f) == __FILE__) || f.start_with?(*%w[bin/ test/ spec/ features/ .git .circleci appveyor sample])
     end
   end
-  spec.bindir = 'exe'
+  spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
-  spec.require_paths = ['lib']
+  spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency 'async'
-  spec.add_dependency 'mini_portile2'
-  spec.add_dependency 'pathspec'
-  spec.add_development_dependency 'debug'
+  spec.add_dependency "async"
+  spec.add_dependency "mini_portile2"
+  spec.add_dependency "pathspec"
+  spec.add_development_dependency "debug"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/lib/kompo.rb
+++ b/lib/kompo.rb
@@ -1,52 +1,52 @@
 # frozen_string_literal: true
 
-require 'taski'
-require_relative 'kompo/version'
+require "taski"
+require_relative "kompo/version"
 
 module Kompo
   # Fixed path prefix for Ruby installation
   # Using a fixed path ensures that cached Ruby binaries work correctly,
   # since Ruby has hardcoded paths for standard library locations.
-  KOMPO_PREFIX = '/kompo'
+  KOMPO_PREFIX = "/kompo"
 
   # Utility classes
-  autoload :KompoIgnore, 'kompo/kompo_ignore'
+  autoload :KompoIgnore, "kompo/kompo_ignore"
 
   # Struct to hold file data for embedding (used by MakeFsC)
-  autoload :KompoFile, 'kompo/tasks/make_fs_c'
+  autoload :KompoFile, "kompo/tasks/make_fs_c"
 
   # Core tasks
-  autoload :WorkDir, 'kompo/tasks/work_dir'
-  autoload :CopyProjectFiles, 'kompo/tasks/copy_project_files'
-  autoload :CopyGemfile, 'kompo/tasks/copy_gemfile'
-  autoload :MakeMainC, 'kompo/tasks/make_main_c'
-  autoload :MakeFsC, 'kompo/tasks/make_fs_c'
+  autoload :WorkDir, "kompo/tasks/work_dir"
+  autoload :CopyProjectFiles, "kompo/tasks/copy_project_files"
+  autoload :CopyGemfile, "kompo/tasks/copy_gemfile"
+  autoload :MakeMainC, "kompo/tasks/make_main_c"
+  autoload :MakeFsC, "kompo/tasks/make_fs_c"
 
   # Ruby installation
-  autoload :InstallRuby, 'kompo/tasks/install_ruby'
-  autoload :CheckStdlibs, 'kompo/tasks/check_stdlibs'
+  autoload :InstallRuby, "kompo/tasks/install_ruby"
+  autoload :CheckStdlibs, "kompo/tasks/check_stdlibs"
 
   # Bundle and gem tasks
-  autoload :BundleInstall, 'kompo/tasks/bundle_install'
-  autoload :FindNativeExtensions, 'kompo/tasks/find_native_extensions'
-  autoload :BuildNativeGem, 'kompo/tasks/build_native_gem'
+  autoload :BundleInstall, "kompo/tasks/bundle_install"
+  autoload :FindNativeExtensions, "kompo/tasks/find_native_extensions"
+  autoload :BuildNativeGem, "kompo/tasks/build_native_gem"
 
   # Final packing (Section: macOS uses clang, Linux uses gcc)
-  autoload :CollectDependencies, 'kompo/tasks/collect_dependencies'
-  autoload :Packing, 'kompo/tasks/packing'
+  autoload :CollectDependencies, "kompo/tasks/collect_dependencies"
+  autoload :Packing, "kompo/tasks/packing"
 
   # Homebrew path (macOS)
-  autoload :HomebrewPath, 'kompo/tasks/homebrew'
+  autoload :HomebrewPath, "kompo/tasks/homebrew"
 
   # Platform-specific dependencies (Section: macOS uses Homebrew, Linux checks via pkg-config)
-  autoload :InstallDeps, 'kompo/tasks/install_deps'
+  autoload :InstallDeps, "kompo/tasks/install_deps"
 
   # External tool paths
-  autoload :KompoVfsPath, 'kompo/tasks/kompo_vfs_path'
-  autoload :KompoVfsVersionCheck, 'kompo/tasks/kompo_vfs_version_check'
-  autoload :RubyBuildPath, 'kompo/tasks/ruby_build_path'
-  autoload :CargoPath, 'kompo/tasks/cargo_path'
+  autoload :KompoVfsPath, "kompo/tasks/kompo_vfs_path"
+  autoload :KompoVfsVersionCheck, "kompo/tasks/kompo_vfs_version_check"
+  autoload :RubyBuildPath, "kompo/tasks/ruby_build_path"
+  autoload :CargoPath, "kompo/tasks/cargo_path"
 end
 
 # Load cache methods (module methods, not autoloadable)
-require_relative 'kompo/cache'
+require_relative "kompo/cache"

--- a/lib/kompo/cache.rb
+++ b/lib/kompo/cache.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
-require 'fileutils'
+require "fileutils"
 
 module Kompo
   # Clean the cache for specified Ruby version
   # @param version [String] Ruby version to clean, or "all" to clean all caches
   def self.clean_cache(version)
-    kompo_cache = File.expand_path('~/.kompo/cache')
+    kompo_cache = File.expand_path("~/.kompo/cache")
 
     unless Dir.exist?(kompo_cache)
       puts "Cache directory does not exist: #{kompo_cache}"
       return
     end
 
-    if version == 'all'
+    if version == "all"
       clean_all_caches(kompo_cache)
     else
       clean_version_cache(kompo_cache, version)
@@ -22,7 +22,7 @@ module Kompo
 
   # Clean all caches in the cache directory
   def self.clean_all_caches(kompo_cache)
-    entries = Dir.glob(File.join(kompo_cache, '*'))
+    entries = Dir.glob(File.join(kompo_cache, "*"))
     if entries.empty?
       puts "No caches found in #{kompo_cache}"
       return
@@ -33,7 +33,7 @@ module Kompo
       puts "Removed: #{entry}"
     end
 
-    puts 'All caches cleaned successfully'
+    puts "All caches cleaned successfully"
   end
   private_class_method :clean_all_caches
 
@@ -52,8 +52,8 @@ module Kompo
     real_version_cache = File.realpath(version_cache_dir)
 
     unless real_version_cache.start_with?(real_kompo_cache + File::SEPARATOR) ||
-           real_version_cache == real_kompo_cache
-      puts 'Error: Invalid cache path detected (possible path traversal)'
+        real_version_cache == real_kompo_cache
+      puts "Error: Invalid cache path detected (possible path traversal)"
       return
     end
 

--- a/lib/kompo/kompo_ignore.rb
+++ b/lib/kompo/kompo_ignore.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require 'pathspec'
+require "pathspec"
 
 module Kompo
   # Handler for .kompoignore file
   # Uses pathspec gem for gitignore-compatible pattern matching
   class KompoIgnore
-    FILENAME = '.kompoignore'
+    FILENAME = ".kompoignore"
 
     def initialize(project_dir)
       @project_dir = project_dir

--- a/lib/kompo/tasks/bundle_install.rb
+++ b/lib/kompo/tasks/bundle_install.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'fileutils'
-require 'digest'
-require 'json'
-require 'bundler'
+require "fileutils"
+require "digest"
+require "json"
+require "bundler"
 
 module Kompo
   # Shared helpers for bundle cache operations
@@ -19,7 +19,7 @@ module Kompo
 
     def compute_gemfile_lock_hash
       work_dir = WorkDir.path
-      gemfile_lock_path = File.join(work_dir, 'Gemfile.lock')
+      gemfile_lock_path = File.join(work_dir, "Gemfile.lock")
       return nil unless File.exist?(gemfile_lock_path)
 
       content = File.read(gemfile_lock_path)
@@ -53,10 +53,10 @@ module Kompo
         work_dir = WorkDir.path
         ruby_major_minor = InstallRuby.ruby_major_minor
 
-        @bundle_ruby_dir = File.join(work_dir, 'bundle', 'ruby', "#{ruby_major_minor}.0")
-        @bundler_config_path = File.join(work_dir, '.bundle', 'config')
+        @bundle_ruby_dir = File.join(work_dir, "bundle", "ruby", "#{ruby_major_minor}.0")
+        @bundler_config_path = File.join(work_dir, ".bundle", "config")
 
-        kompo_cache = Taski.args.fetch(:kompo_cache, File.expand_path('~/.kompo/cache'))
+        kompo_cache = Taski.args.fetch(:kompo_cache, File.expand_path("~/.kompo/cache"))
         ruby_version = InstallRuby.ruby_version
         version_cache_dir = File.join(kompo_cache, ruby_version)
 
@@ -65,19 +65,19 @@ module Kompo
 
         cache_dir = File.join(version_cache_dir, bundle_cache_name)
 
-        group('Restoring bundle from cache') do
+        group("Restoring bundle from cache") do
           # Clean up existing files in case work_dir is reused
-          FileUtils.rm_rf(File.join(work_dir, 'bundle')) if Dir.exist?(File.join(work_dir, 'bundle'))
-          FileUtils.rm_rf(File.join(work_dir, '.bundle')) if Dir.exist?(File.join(work_dir, '.bundle'))
+          FileUtils.rm_rf(File.join(work_dir, "bundle")) if Dir.exist?(File.join(work_dir, "bundle"))
+          FileUtils.rm_rf(File.join(work_dir, ".bundle")) if Dir.exist?(File.join(work_dir, ".bundle"))
 
           # Copy from cache
-          FileUtils.cp_r(File.join(cache_dir, 'bundle'), File.join(work_dir, 'bundle'))
-          FileUtils.cp_r(File.join(cache_dir, '.bundle'), File.join(work_dir, '.bundle'))
+          FileUtils.cp_r(File.join(cache_dir, "bundle"), File.join(work_dir, "bundle"))
+          FileUtils.cp_r(File.join(cache_dir, ".bundle"), File.join(work_dir, ".bundle"))
 
           puts "Restored from: #{cache_dir}"
         end
 
-        puts 'Bundle restored from cache'
+        puts "Bundle restored from cache"
       end
 
       def clean
@@ -89,7 +89,7 @@ module Kompo
 
           FileUtils.rm_rf(path) if File.exist?(path)
         end
-        puts 'Cleaned up bundle installation'
+        puts "Cleaned up bundle installation"
       end
     end
 
@@ -102,33 +102,33 @@ module Kompo
         bundler = InstallRuby.bundler_path
         ruby_major_minor = InstallRuby.ruby_major_minor
 
-        @bundle_ruby_dir = File.join(work_dir, 'bundle', 'ruby', "#{ruby_major_minor}.0")
-        @bundler_config_path = File.join(work_dir, '.bundle', 'config')
+        @bundle_ruby_dir = File.join(work_dir, "bundle", "ruby", "#{ruby_major_minor}.0")
+        @bundler_config_path = File.join(work_dir, ".bundle", "config")
 
-        puts 'Running bundle install --path bundle...'
-        gemfile_path = File.join(work_dir, 'Gemfile')
+        puts "Running bundle install --path bundle..."
+        gemfile_path = File.join(work_dir, "Gemfile")
 
         # Clear Bundler environment and specify Gemfile path explicitly
         Bundler.with_unbundled_env do
           ruby = InstallRuby.ruby_path
-          env = { 'BUNDLE_GEMFILE' => gemfile_path }
+          env = {"BUNDLE_GEMFILE" => gemfile_path}
 
           # Suppress clang 18+ warning that causes mkmf try_cppflags to fail
           # This flag is clang-specific and not recognized by GCC
           if clang_compiler?
-            env['CFLAGS'] = '-Wno-default-const-init-field-unsafe'
-            env['CPPFLAGS'] = '-Wno-default-const-init-field-unsafe'
+            env["CFLAGS"] = "-Wno-default-const-init-field-unsafe"
+            env["CPPFLAGS"] = "-Wno-default-const-init-field-unsafe"
           end
 
           # Set BUNDLE_PATH to "bundle" - standard Bundler reads .bundle/config
           # and finds gems in {BUNDLE_PATH}/ruby/X.X.X/gems/
           # Use ruby to execute bundler to avoid shebang issues
-          system({ 'BUNDLE_GEMFILE' => gemfile_path }, ruby, bundler, 'config', 'set', '--local', 'path',
-                 'bundle') or raise 'Failed to set bundle path'
-          system(env, ruby, bundler, 'install') or raise 'Failed to run bundle install'
+          system({"BUNDLE_GEMFILE" => gemfile_path}, ruby, bundler, "config", "set", "--local", "path",
+            "bundle") or raise "Failed to set bundle path"
+          system(env, ruby, bundler, "install") or raise "Failed to run bundle install"
         end
 
-        puts 'Bundle installed successfully'
+        puts "Bundle installed successfully"
 
         # Save to cache
         save_to_cache(work_dir)
@@ -143,18 +143,18 @@ module Kompo
 
           FileUtils.rm_rf(path) if File.exist?(path)
         end
-        puts 'Cleaned up bundle installation'
+        puts "Cleaned up bundle installation"
       end
 
       private
 
       def clang_compiler?
         output = `cc --version 2>&1`
-        output.include?('clang')
+        output.include?("clang")
       rescue Errno::ENOENT => e
         warn "cc command not found: #{e.message}"
         false
-      rescue StandardError => e
+      rescue => e
         warn "Error checking compiler: #{e.message}"
         false
       end
@@ -163,27 +163,27 @@ module Kompo
         bundle_cache_name = compute_bundle_cache_name
         return unless bundle_cache_name
 
-        kompo_cache = Taski.args.fetch(:kompo_cache, File.expand_path('~/.kompo/cache'))
+        kompo_cache = Taski.args.fetch(:kompo_cache, File.expand_path("~/.kompo/cache"))
         ruby_version = InstallRuby.ruby_version
         version_cache_dir = File.join(kompo_cache, ruby_version)
         cache_dir = File.join(version_cache_dir, bundle_cache_name)
 
-        group('Saving bundle to cache') do
+        group("Saving bundle to cache") do
           # Remove old cache if exists
           FileUtils.rm_rf(cache_dir) if Dir.exist?(cache_dir)
           FileUtils.mkdir_p(cache_dir)
 
           # Copy to cache
-          FileUtils.cp_r(File.join(work_dir, 'bundle'), File.join(cache_dir, 'bundle'))
-          FileUtils.cp_r(File.join(work_dir, '.bundle'), File.join(cache_dir, '.bundle'))
+          FileUtils.cp_r(File.join(work_dir, "bundle"), File.join(cache_dir, "bundle"))
+          FileUtils.cp_r(File.join(work_dir, ".bundle"), File.join(cache_dir, ".bundle"))
 
           # Save metadata
           metadata = {
-            'ruby_version' => ruby_version,
-            'gemfile_lock_hash' => compute_gemfile_lock_hash,
-            'created_at' => Time.now.iso8601
+            "ruby_version" => ruby_version,
+            "gemfile_lock_hash" => compute_gemfile_lock_hash,
+            "created_at" => Time.now.iso8601
           }
-          File.write(File.join(cache_dir, 'metadata.json'), JSON.pretty_generate(metadata))
+          File.write(File.join(cache_dir, "metadata.json"), JSON.pretty_generate(metadata))
 
           puts "Saved to: #{cache_dir}"
         end
@@ -193,7 +193,7 @@ module Kompo
     # Skip bundle install when no Gemfile
     class Skip < Taski::Task
       def run
-        puts 'No Gemfile, skipping bundle install'
+        puts "No Gemfile, skipping bundle install"
         @bundle_ruby_dir = nil
         @bundler_config_path = nil
       end
@@ -209,14 +209,14 @@ module Kompo
       bundle_cache_name = compute_bundle_cache_name
       return false unless bundle_cache_name
 
-      kompo_cache = Taski.args.fetch(:kompo_cache, File.expand_path('~/.kompo/cache'))
+      kompo_cache = Taski.args.fetch(:kompo_cache, File.expand_path("~/.kompo/cache"))
       ruby_version = InstallRuby.ruby_version
       version_cache_dir = File.join(kompo_cache, ruby_version)
       cache_dir = File.join(version_cache_dir, bundle_cache_name)
 
-      cache_bundle_dir = File.join(cache_dir, 'bundle')
-      cache_bundle_config = File.join(cache_dir, '.bundle')
-      cache_metadata = File.join(cache_dir, 'metadata.json')
+      cache_bundle_dir = File.join(cache_dir, "bundle")
+      cache_bundle_config = File.join(cache_dir, ".bundle")
+      cache_metadata = File.join(cache_dir, "metadata.json")
 
       Dir.exist?(cache_bundle_dir) && Dir.exist?(cache_bundle_config) && File.exist?(cache_metadata)
     end

--- a/lib/kompo/tasks/cargo_path.rb
+++ b/lib/kompo/tasks/cargo_path.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'open3'
+require "open3"
 
 module Kompo
   # Section to get the Cargo path.
@@ -16,15 +16,15 @@ module Kompo
     class Installed < Taski::Task
       def run
         # First check PATH, then fallback to default rustup location
-        cargo_in_path, = Open3.capture2('which', 'cargo', err: File::NULL)
+        cargo_in_path, = Open3.capture2("which", "cargo", err: File::NULL)
         cargo_in_path = cargo_in_path.chomp
         @path = if cargo_in_path.empty?
-                  File.expand_path('~/.cargo/bin/cargo')
-                else
-                  cargo_in_path
-                end
+          File.expand_path("~/.cargo/bin/cargo")
+        else
+          cargo_in_path
+        end
         puts "Cargo path: #{@path}"
-        version_output, = Open3.capture2e(@path, '--version')
+        version_output, = Open3.capture2e(@path, "--version")
         puts "Cargo version: #{version_output.chomp}"
       end
     end
@@ -32,14 +32,14 @@ module Kompo
     # Install Cargo via rustup and return the path
     class Install < Taski::Task
       def run
-        puts 'Cargo not found. Installing via rustup...'
+        puts "Cargo not found. Installing via rustup..."
         system("curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y")
 
-        @path = File.expand_path('~/.cargo/bin/cargo')
-        raise 'Failed to install Cargo' unless File.executable?(@path)
+        @path = File.expand_path("~/.cargo/bin/cargo")
+        raise "Failed to install Cargo" unless File.executable?(@path)
 
         puts "Cargo installed at: #{@path}"
-        version_output, = Open3.capture2e(@path, '--version')
+        version_output, = Open3.capture2e(@path, "--version")
         puts "Cargo version: #{version_output.chomp}"
       end
     end
@@ -48,11 +48,11 @@ module Kompo
 
     def cargo_installed?
       # Check if cargo is in PATH
-      cargo_in_path, = Open3.capture2('which', 'cargo', err: File::NULL)
+      cargo_in_path, = Open3.capture2("which", "cargo", err: File::NULL)
       return true unless cargo_in_path.chomp.empty?
 
       # Check default rustup installation location
-      home_cargo = File.expand_path('~/.cargo/bin/cargo')
+      home_cargo = File.expand_path("~/.cargo/bin/cargo")
       File.executable?(home_cargo)
     end
   end

--- a/lib/kompo/tasks/check_stdlibs.rb
+++ b/lib/kompo/tasks/check_stdlibs.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'open3'
+require "open3"
 
 module Kompo
   # Get Ruby standard library paths from installed Ruby
@@ -12,7 +12,7 @@ module Kompo
       no_stdlib = Taski.args.fetch(:no_stdlib, false)
       if no_stdlib
         @paths = []
-        puts 'Skipping standard library (--no-stdlib)'
+        puts "Skipping standard library (--no-stdlib)"
         return
       end
 
@@ -24,9 +24,9 @@ module Kompo
       # Include the Ruby standard library root directory
       # This includes bundler and other default gems that are not in $:
       # Ruby uses "X.Y.0" format for lib/ruby paths (e.g., "3.4.0" not "3.4")
-      stdlib_root = File.join(ruby_install_dir, 'lib', 'ruby', "#{ruby_major_minor}.0")
+      stdlib_root = File.join(ruby_install_dir, "lib", "ruby", "#{ruby_major_minor}.0")
       # RubyGems needs gemspec files in specifications/ directory
-      gems_specs_root = File.join(ruby_install_dir, 'lib', 'ruby', 'gems', "#{ruby_major_minor}.0", 'specifications')
+      gems_specs_root = File.join(ruby_install_dir, "lib", "ruby", "gems", "#{ruby_major_minor}.0", "specifications")
 
       if Dir.exist?(stdlib_root)
         @paths = [stdlib_root, gems_specs_root].select { |p| Dir.exist?(p) }
@@ -34,7 +34,7 @@ module Kompo
         puts "Including gem specifications: #{gems_specs_root}" if Dir.exist?(gems_specs_root)
       else
         # Fallback to $: paths if stdlib root doesn't exist
-        output, status = Open3.capture2(ruby, '-e', 'puts $:', err: File::NULL)
+        output, status = Open3.capture2(ruby, "-e", "puts $:", err: File::NULL)
         unless status.success?
           raise "Failed to get Ruby standard library paths: exit code #{status.exitstatus}, output: #{output}"
         end
@@ -42,7 +42,7 @@ module Kompo
         raw_paths = output.split("\n").reject(&:empty?)
 
         @paths = raw_paths.map do |path|
-          next nil unless path.start_with?('/')
+          next nil unless path.start_with?("/")
 
           if original_ruby_install_dir != ruby_install_dir && path.start_with?(original_ruby_install_dir)
             path.sub(original_ruby_install_dir, ruby_install_dir)

--- a/lib/kompo/tasks/collect_dependencies.rb
+++ b/lib/kompo/tasks/collect_dependencies.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'fileutils'
+require "fileutils"
 
 module Kompo
   # Collect all dependencies for packing.
@@ -20,7 +20,7 @@ module Kompo
       project_dir = Taski.args.fetch(:project_dir, Taski.env.working_directory) || Taski.env.working_directory
       output_arg = Taski.args.fetch(:output_dir, Taski.env.working_directory) || Taski.env.working_directory
 
-      @deps = group('Collecting dependencies') do
+      @deps = group("Collecting dependencies") do
         collect_dependencies
       end
 
@@ -36,12 +36,12 @@ module Kompo
 
       @ext_paths = get_unique_ext_paths(@work_dir, @deps.ruby_build_path, @deps.ruby_version, @deps.exts_dir)
       @enc_files = [
-        File.join(@deps.ruby_build_path, "ruby-#{@deps.ruby_version}", 'enc/encinit.o'),
-        File.join(@deps.ruby_build_path, "ruby-#{@deps.ruby_version}", 'enc/libenc.a'),
-        File.join(@deps.ruby_build_path, "ruby-#{@deps.ruby_version}", 'enc/libtrans.a')
+        File.join(@deps.ruby_build_path, "ruby-#{@deps.ruby_version}", "enc/encinit.o"),
+        File.join(@deps.ruby_build_path, "ruby-#{@deps.ruby_version}", "enc/libenc.a"),
+        File.join(@deps.ruby_build_path, "ruby-#{@deps.ruby_version}", "enc/libtrans.a")
       ]
 
-      puts 'All dependencies collected for packing'
+      puts "All dependencies collected for packing"
     end
 
     private
@@ -55,14 +55,14 @@ module Kompo
       ruby_version = InstallRuby.ruby_version
       ruby_major_minor = InstallRuby.ruby_major_minor
       ruby_build_path = InstallRuby.ruby_build_path
-      ruby_lib = File.join(ruby_install_dir, 'lib')
+      ruby_lib = File.join(ruby_install_dir, "lib")
 
       kompo_lib = KompoVfsPath.path
       main_c = MakeMainC.path
       fs_c = MakeFsC.path
       exts_dir = BuildNativeGem.exts_dir
 
-      puts 'Dependencies collected'
+      puts "Dependencies collected"
 
       Dependencies.new(
         ruby_install_dir: ruby_install_dir,
@@ -82,26 +82,26 @@ module Kompo
       ruby_build_dir = File.join(ruby_build_path, "ruby-#{ruby_version}")
 
       # Ruby standard extension .o files
-      paths = Dir.glob(File.join(ruby_build_dir, 'ext', '**', '*.o'))
+      paths = Dir.glob(File.join(ruby_build_dir, "ext", "**", "*.o"))
 
       # Ruby bundled gems .o files (Ruby 4.0+)
       # Skip if --no-stdlib is specified (bundled gems are part of stdlib)
       no_stdlib = Taski.args.fetch(:no_stdlib, false)
       unless no_stdlib
-        bundled_gems_paths = Dir.glob(File.join(ruby_build_dir, '.bundle', 'gems', '*', 'ext', '**', '*.o'))
+        bundled_gems_paths = Dir.glob(File.join(ruby_build_dir, ".bundle", "gems", "*", "ext", "**", "*.o"))
         paths += bundled_gems_paths
       end
 
       # Extract extension path (everything after /ext/) for deduplication
       # e.g., ".../ext/cgi/escape/escape.o" -> "cgi/escape/escape.o"
-      ruby_ext_keys = paths.map { |p| p.split('/ext/').last }
+      ruby_ext_keys = paths.map { |p| p.split("/ext/").last }
 
       # Gem extension .o files (excluding duplicates with Ruby std)
       if exts_dir && Dir.exist?(exts_dir)
         gem_ext_paths = Dir.glob("#{exts_dir}/**/*.o")
-                           .to_h { |p| [p.split('/ext/').last, p] }
-                           .except(*ruby_ext_keys)
-                           .values
+          .to_h { |p| [p.split("/ext/").last, p] }
+          .except(*ruby_ext_keys)
+          .values
         paths += gem_ext_paths
       end
 

--- a/lib/kompo/tasks/copy_gemfile.rb
+++ b/lib/kompo/tasks/copy_gemfile.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'fileutils'
+require "fileutils"
 
 module Kompo
   # Copy Gemfile, Gemfile.lock, and gemspec files to working directory if they exist
@@ -13,31 +13,31 @@ module Kompo
 
       # Skip Gemfile processing if --no-gemfile is specified
       if Taski.args[:no_gemfile]
-        puts 'Skipping Gemfile (--no-gemfile specified)'
+        puts "Skipping Gemfile (--no-gemfile specified)"
         @gemfile_exists = false
         @gemspec_paths = []
         return
       end
 
-      gemfile_path = File.join(project_dir, 'Gemfile')
-      gemfile_lock_path = File.join(project_dir, 'Gemfile.lock')
+      gemfile_path = File.join(project_dir, "Gemfile")
+      gemfile_lock_path = File.join(project_dir, "Gemfile.lock")
 
       @gemfile_exists = File.exist?(gemfile_path)
       @gemspec_paths = []
 
       if @gemfile_exists
         FileUtils.cp(gemfile_path, work_dir)
-        puts 'Copied: Gemfile'
+        puts "Copied: Gemfile"
 
         if File.exist?(gemfile_lock_path)
           FileUtils.cp(gemfile_lock_path, work_dir)
-          puts 'Copied: Gemfile.lock'
+          puts "Copied: Gemfile.lock"
         end
 
         # Copy gemspec files if Gemfile references gemspec
         copy_gemspec_if_needed(gemfile_path, project_dir, work_dir)
       else
-        puts 'No Gemfile found, skipping'
+        puts "No Gemfile found, skipping"
       end
     end
 
@@ -47,8 +47,8 @@ module Kompo
       work_dir = WorkDir.path
       return unless work_dir && Dir.exist?(work_dir)
 
-      gemfile = File.join(work_dir, 'Gemfile')
-      gemfile_lock = File.join(work_dir, 'Gemfile.lock')
+      gemfile = File.join(work_dir, "Gemfile")
+      gemfile_lock = File.join(work_dir, "Gemfile.lock")
 
       FileUtils.rm_f(gemfile)
       FileUtils.rm_f(gemfile_lock)
@@ -58,7 +58,7 @@ module Kompo
         FileUtils.rm_f(gemspec)
       end
 
-      puts 'Cleaned up Gemfile'
+      puts "Cleaned up Gemfile"
     end
 
     private
@@ -70,7 +70,7 @@ module Kompo
       return unless gemfile_content.match?(/^\s*gemspec\b/)
 
       # Copy all .gemspec files from project directory
-      gemspec_files = Dir.glob(File.join(project_dir, '*.gemspec'))
+      gemspec_files = Dir.glob(File.join(project_dir, "*.gemspec"))
       gemspec_files.each do |gemspec_path|
         dest_path = File.join(work_dir, File.basename(gemspec_path))
         FileUtils.cp(gemspec_path, dest_path)
@@ -79,7 +79,7 @@ module Kompo
       end
 
       if gemspec_files.empty?
-        warn 'Warning: Gemfile contains gemspec directive but no .gemspec files found'
+        warn "Warning: Gemfile contains gemspec directive but no .gemspec files found"
       end
     end
   end

--- a/lib/kompo/tasks/copy_project_files.rb
+++ b/lib/kompo/tasks/copy_project_files.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'fileutils'
+require "fileutils"
 
 module Kompo
   # Copy project files (entrypoint and additional files) to working directory
@@ -10,7 +10,7 @@ module Kompo
     def run
       work_dir = WorkDir.path
       project_dir = Taski.args.fetch(:project_dir, Taski.env.working_directory) || Taski.env.working_directory
-      entrypoint = Taski.args.fetch(:entrypoint, 'main.rb')
+      entrypoint = Taski.args.fetch(:entrypoint, "main.rb")
       files = Taski.args.fetch(:files, [])
 
       # Copy entrypoint (preserve relative path structure)
@@ -54,7 +54,7 @@ module Kompo
 
         if File.directory?(src)
           # Special handling for "." - copy directory contents directly to work_dir
-          if file == '.' || real_src == real_project_dir
+          if file == "." || real_src == real_project_dir
             copy_directory_contents(src, work_dir)
             @additional_paths << work_dir
           else
@@ -90,7 +90,7 @@ module Kompo
         # Only delete if path is inside work_dir
         FileUtils.rm_rf(path) if expanded_path.start_with?(real_work_dir + File::SEPARATOR) && File.exist?(path)
       end
-      puts 'Cleaned up project files'
+      puts "Cleaned up project files"
     end
 
     private

--- a/lib/kompo/tasks/find_native_extensions.rb
+++ b/lib/kompo/tasks/find_native_extensions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'open3'
+require "open3"
 
 module Kompo
   # Find native gem extensions that need to be built
@@ -23,13 +23,13 @@ module Kompo
       # Skip if --no-stdlib is specified (bundled gems are part of stdlib)
       no_stdlib = Taski.args.fetch(:no_stdlib, false)
       unless no_stdlib
-        bundled_gems_dir = File.join(ruby_build_path, "ruby-#{ruby_version}", '.bundle', 'gems')
+        bundled_gems_dir = File.join(ruby_build_path, "ruby-#{ruby_version}", ".bundle", "gems")
         find_bundled_gem_extensions(bundled_gems_dir, builtin_init_funcs)
       end
 
       # Skip user gems if no Gemfile
       unless CopyGemfile.gemfile_exists
-        puts 'No Gemfile, skipping user gem native extensions'
+        puts "No Gemfile, skipping user gem native extensions"
         puts "Found #{@extensions.size} native extensions to build"
         return
       end
@@ -37,7 +37,7 @@ module Kompo
       bundle_ruby_dir = BundleInstall.bundle_ruby_dir
 
       # Find all native extensions in installed gems
-      extconf_files = Dir.glob(File.join(bundle_ruby_dir, 'gems/**/extconf.rb'))
+      extconf_files = Dir.glob(File.join(bundle_ruby_dir, "gems/**/extconf.rb"))
 
       extconf_files.each do |extconf_path|
         dir_name = File.dirname(extconf_path)
@@ -52,8 +52,8 @@ module Kompo
         end
 
         # Skip if this extension is part of Ruby standard library
-        ruby_std_lib = dir_name.split('/').drop_while { |p| p != 'ext' }.join('/')
-        ruby_ext_objects = Dir.glob(File.join(ruby_build_path, "ruby-#{ruby_version}", 'ext', '**', '*.o'))
+        ruby_std_lib = dir_name.split("/").drop_while { |p| p != "ext" }.join("/")
+        ruby_ext_objects = Dir.glob(File.join(ruby_build_path, "ruby-#{ruby_version}", "ext", "**", "*.o"))
         if ruby_ext_objects.any? { |o| o.include?(ruby_std_lib) }
           puts "skip: #{gem_ext_name} is included in Ruby standard library"
           next
@@ -74,7 +74,7 @@ module Kompo
           end
         end
 
-        cargo_toml = File.join(dir_name, 'Cargo.toml')
+        cargo_toml = File.join(dir_name, "Cargo.toml")
         is_rust = File.exist?(cargo_toml)
 
         @extensions << {
@@ -96,7 +96,7 @@ module Kompo
     def find_bundled_gem_extensions(bundled_gems_dir, builtin_init_funcs)
       return unless Dir.exist?(bundled_gems_dir)
 
-      extconf_files = Dir.glob(File.join(bundled_gems_dir, '**/extconf.rb'))
+      extconf_files = Dir.glob(File.join(bundled_gems_dir, "**/extconf.rb"))
 
       extconf_files.each do |extconf_path|
         dir_name = File.dirname(extconf_path)
@@ -111,7 +111,7 @@ module Kompo
 
         # Verify that .o files exist (pre-built)
         # Search recursively since object files may be in subdirectories
-        o_files = Dir.glob(File.join(dir_name, '**', '*.o'))
+        o_files = Dir.glob(File.join(dir_name, "**", "*.o"))
         if o_files.empty?
           puts "skip: #{gem_ext_name} has no pre-built .o files"
           next
@@ -130,13 +130,13 @@ module Kompo
 
     # Extract Init_ function names from libruby-static using nm
     def get_builtin_init_functions(ruby_install_dir)
-      lib_dir = File.join(ruby_install_dir, 'lib')
-      static_lib = Dir.glob(File.join(lib_dir, 'libruby*-static.a')).first
+      lib_dir = File.join(ruby_install_dir, "lib")
+      static_lib = Dir.glob(File.join(lib_dir, "libruby*-static.a")).first
       return Set.new unless static_lib
 
       # Use nm to extract defined Init_ symbols (T = text/code section)
       # Use Open3.capture2 with array form to avoid shell injection
-      output, status = Open3.capture2('nm', static_lib, err: File::NULL)
+      output, status = Open3.capture2("nm", static_lib, err: File::NULL)
       return Set.new unless status.success?
 
       # Filter lines matching " T _?Init_" pattern and extract the symbol name
@@ -145,7 +145,7 @@ module Kompo
       symbols.map do |line|
         # Third whitespace-separated field is the symbol name
         symbol = line.split[2]
-        symbol&.delete_prefix('_')
+        symbol&.delete_prefix("_")
       end.compact.to_set
     end
   end

--- a/lib/kompo/tasks/homebrew.rb
+++ b/lib/kompo/tasks/homebrew.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'open3'
+require "open3"
 
 module Kompo
   # Section to get the Homebrew path.
@@ -9,7 +9,7 @@ module Kompo
     interfaces :path
 
     # Common Homebrew installation paths
-    COMMON_BREW_PATHS = ['/opt/homebrew/bin/brew', '/usr/local/bin/brew'].freeze
+    COMMON_BREW_PATHS = ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"].freeze
 
     def impl
       homebrew_installed? ? Installed : Install
@@ -19,27 +19,27 @@ module Kompo
     class Installed < Taski::Task
       def run
         # First check PATH
-        brew_in_path, = Open3.capture2('which', 'brew', err: File::NULL)
+        brew_in_path, = Open3.capture2("which", "brew", err: File::NULL)
         brew_in_path = brew_in_path.chomp
         @path = if brew_in_path.empty?
-                  # Fallback to common installation paths
-                  HomebrewPath::COMMON_BREW_PATHS.find { |p| File.executable?(p) }
-                else
-                  brew_in_path
-                end
+          # Fallback to common installation paths
+          HomebrewPath::COMMON_BREW_PATHS.find { |p| File.executable?(p) }
+        else
+          brew_in_path
+        end
         puts "Homebrew path: #{@path}"
       end
     end
 
     # Install Homebrew
     class Install < Taski::Task
-      MARKER_FILE = File.expand_path('~/.kompo_installed_homebrew')
+      MARKER_FILE = File.expand_path("~/.kompo_installed_homebrew")
 
       def run
-        puts 'Homebrew not found. Installing...'
+        puts "Homebrew not found. Installing..."
         system('/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"')
 
-        brew_in_path, = Open3.capture2('which', 'brew', err: File::NULL)
+        brew_in_path, = Open3.capture2("which", "brew", err: File::NULL)
         @path = brew_in_path.chomp
         if @path.empty?
           # Check common installation paths
@@ -51,7 +51,7 @@ module Kompo
           end
         end
 
-        raise 'Failed to install Homebrew' if @path.nil? || @path.empty?
+        raise "Failed to install Homebrew" if @path.nil? || @path.empty?
 
         # Mark that kompo installed Homebrew
         File.write(MARKER_FILE, @path)
@@ -62,10 +62,10 @@ module Kompo
         # Only uninstall if kompo installed it
         return unless File.exist?(MARKER_FILE)
 
-        puts 'Uninstalling Homebrew (installed by kompo)...'
+        puts "Uninstalling Homebrew (installed by kompo)..."
         system('NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"')
         File.delete(MARKER_FILE) if File.exist?(MARKER_FILE)
-        puts 'Homebrew uninstalled'
+        puts "Homebrew uninstalled"
       end
     end
 
@@ -73,7 +73,7 @@ module Kompo
 
     def homebrew_installed?
       # Check if brew is in PATH
-      brew_in_path, = Open3.capture2('which', 'brew', err: File::NULL)
+      brew_in_path, = Open3.capture2("which", "brew", err: File::NULL)
       return true unless brew_in_path.chomp.empty?
 
       # Check common installation paths

--- a/lib/kompo/tasks/install_deps.rb
+++ b/lib/kompo/tasks/install_deps.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'English'
+require "English"
 module Kompo
   # Section to handle platform-specific dependencies.
   # Switches implementation based on the current platform.
@@ -23,9 +23,9 @@ module Kompo
           InstallLibyaml.lib_path,
           InstallZlib.lib_path,
           InstallLibffi.lib_path
-        ].compact.join(' ')
+        ].compact.join(" ")
 
-        puts 'All Homebrew dependencies installed'
+        puts "All Homebrew dependencies installed"
       end
 
       # GMP library installation Section
@@ -37,8 +37,8 @@ module Kompo
           system("#{brew} list #{BREW_NAME} > /dev/null 2>&1") ? Installed : Install
         end
 
-        BREW_NAME = 'gmp'
-        MARKER_FILE = File.expand_path('~/.kompo_installed_gmp')
+        BREW_NAME = "gmp"
+        MARKER_FILE = File.expand_path("~/.kompo_installed_gmp")
 
         class Installed < Taski::Task
           def run
@@ -54,7 +54,7 @@ module Kompo
             brew = HomebrewPath.path
             puts "Installing #{BREW_NAME}..."
             system("#{brew} install #{BREW_NAME}") or raise "Failed to install #{BREW_NAME}"
-            File.write(MARKER_FILE, 'installed')
+            File.write(MARKER_FILE, "installed")
 
             prefix = `#{brew} --prefix #{BREW_NAME} 2>/dev/null`.chomp
             @lib_path = "-L#{prefix}/lib" if $CHILD_STATUS.success? && !prefix.empty?
@@ -80,8 +80,8 @@ module Kompo
           system("#{brew} list #{BREW_NAME} > /dev/null 2>&1") ? Installed : Install
         end
 
-        BREW_NAME = 'openssl@3'
-        MARKER_FILE = File.expand_path('~/.kompo_installed_openssl')
+        BREW_NAME = "openssl@3"
+        MARKER_FILE = File.expand_path("~/.kompo_installed_openssl")
 
         class Installed < Taski::Task
           def run
@@ -97,7 +97,7 @@ module Kompo
             brew = HomebrewPath.path
             puts "Installing #{BREW_NAME}..."
             system("#{brew} install #{BREW_NAME}") or raise "Failed to install #{BREW_NAME}"
-            File.write(MARKER_FILE, 'installed')
+            File.write(MARKER_FILE, "installed")
 
             prefix = `#{brew} --prefix #{BREW_NAME} 2>/dev/null`.chomp
             @lib_path = "-L#{prefix}/lib" if $CHILD_STATUS.success? && !prefix.empty?
@@ -123,8 +123,8 @@ module Kompo
           system("#{brew} list #{BREW_NAME} > /dev/null 2>&1") ? Installed : Install
         end
 
-        BREW_NAME = 'readline'
-        MARKER_FILE = File.expand_path('~/.kompo_installed_readline')
+        BREW_NAME = "readline"
+        MARKER_FILE = File.expand_path("~/.kompo_installed_readline")
 
         class Installed < Taski::Task
           def run
@@ -140,7 +140,7 @@ module Kompo
             brew = HomebrewPath.path
             puts "Installing #{BREW_NAME}..."
             system("#{brew} install #{BREW_NAME}") or raise "Failed to install #{BREW_NAME}"
-            File.write(MARKER_FILE, 'installed')
+            File.write(MARKER_FILE, "installed")
 
             prefix = `#{brew} --prefix #{BREW_NAME} 2>/dev/null`.chomp
             @lib_path = "-L#{prefix}/lib" if $CHILD_STATUS.success? && !prefix.empty?
@@ -166,8 +166,8 @@ module Kompo
           system("#{brew} list #{BREW_NAME} > /dev/null 2>&1") ? Installed : Install
         end
 
-        BREW_NAME = 'libyaml'
-        MARKER_FILE = File.expand_path('~/.kompo_installed_libyaml')
+        BREW_NAME = "libyaml"
+        MARKER_FILE = File.expand_path("~/.kompo_installed_libyaml")
 
         class Installed < Taski::Task
           def run
@@ -183,7 +183,7 @@ module Kompo
             brew = HomebrewPath.path
             puts "Installing #{BREW_NAME}..."
             system("#{brew} install #{BREW_NAME}") or raise "Failed to install #{BREW_NAME}"
-            File.write(MARKER_FILE, 'installed')
+            File.write(MARKER_FILE, "installed")
 
             prefix = `#{brew} --prefix #{BREW_NAME} 2>/dev/null`.chomp
             @lib_path = "-L#{prefix}/lib" if $CHILD_STATUS.success? && !prefix.empty?
@@ -209,8 +209,8 @@ module Kompo
           system("#{brew} list #{BREW_NAME} > /dev/null 2>&1") ? Installed : Install
         end
 
-        BREW_NAME = 'zlib'
-        MARKER_FILE = File.expand_path('~/.kompo_installed_zlib')
+        BREW_NAME = "zlib"
+        MARKER_FILE = File.expand_path("~/.kompo_installed_zlib")
 
         class Installed < Taski::Task
           def run
@@ -226,7 +226,7 @@ module Kompo
             brew = HomebrewPath.path
             puts "Installing #{BREW_NAME}..."
             system("#{brew} install #{BREW_NAME}") or raise "Failed to install #{BREW_NAME}"
-            File.write(MARKER_FILE, 'installed')
+            File.write(MARKER_FILE, "installed")
 
             prefix = `#{brew} --prefix #{BREW_NAME} 2>/dev/null`.chomp
             @lib_path = "-L#{prefix}/lib" if $CHILD_STATUS.success? && !prefix.empty?
@@ -252,8 +252,8 @@ module Kompo
           system("#{brew} list #{BREW_NAME} > /dev/null 2>&1") ? Installed : Install
         end
 
-        BREW_NAME = 'libffi'
-        MARKER_FILE = File.expand_path('~/.kompo_installed_libffi')
+        BREW_NAME = "libffi"
+        MARKER_FILE = File.expand_path("~/.kompo_installed_libffi")
 
         class Installed < Taski::Task
           def run
@@ -269,7 +269,7 @@ module Kompo
             brew = HomebrewPath.path
             puts "Installing #{BREW_NAME}..."
             system("#{brew} install #{BREW_NAME}") or raise "Failed to install #{BREW_NAME}"
-            File.write(MARKER_FILE, 'installed')
+            File.write(MARKER_FILE, "installed")
 
             prefix = `#{brew} --prefix #{BREW_NAME} 2>/dev/null`.chomp
             @lib_path = "-L#{prefix}/lib" if $CHILD_STATUS.success? && !prefix.empty?
@@ -291,30 +291,30 @@ module Kompo
     class ForLinux < Taski::Task
       def run
         unless pkg_config_available?
-          puts '[WARNING] pkg-config not found. Skipping dependency check.'
-          puts 'Install pkg-config to enable automatic dependency verification.'
-          @lib_paths = ''
+          puts "[WARNING] pkg-config not found. Skipping dependency check."
+          puts "Install pkg-config to enable automatic dependency verification."
+          @lib_paths = ""
           return
         end
 
         check_dependencies
         @lib_paths = collect_lib_paths
 
-        puts 'All required development libraries are installed.'
+        puts "All required development libraries are installed."
       end
 
       REQUIRED_LIBS = {
-        'openssl' => { pkg_config: 'openssl', apt: 'libssl-dev', yum: 'openssl-devel' },
-        'readline' => { pkg_config: 'readline', apt: 'libreadline-dev', yum: 'readline-devel' },
-        'zlib' => { pkg_config: 'zlib', apt: 'zlib1g-dev', yum: 'zlib-devel' },
-        'libyaml' => { pkg_config: 'yaml-0.1', apt: 'libyaml-dev', yum: 'libyaml-devel' },
-        'libffi' => { pkg_config: 'libffi', apt: 'libffi-dev', yum: 'libffi-devel' }
+        "openssl" => {pkg_config: "openssl", apt: "libssl-dev", yum: "openssl-devel"},
+        "readline" => {pkg_config: "readline", apt: "libreadline-dev", yum: "readline-devel"},
+        "zlib" => {pkg_config: "zlib", apt: "zlib1g-dev", yum: "zlib-devel"},
+        "libyaml" => {pkg_config: "yaml-0.1", apt: "libyaml-dev", yum: "libyaml-devel"},
+        "libffi" => {pkg_config: "libffi", apt: "libffi-dev", yum: "libffi-devel"}
       }.freeze
 
       private
 
       def pkg_config_available?
-        system('which pkg-config > /dev/null 2>&1')
+        system("which pkg-config > /dev/null 2>&1")
       end
 
       def check_dependencies
@@ -330,13 +330,13 @@ module Kompo
         paths = pkg_names.flat_map do |pkg|
           `pkg-config --libs-only-L #{pkg} 2>/dev/null`.chomp.split
         end
-        paths.uniq.join(' ')
+        paths.uniq.join(" ")
       end
 
       def build_error_message(missing)
-        lib_names = missing.keys.join(', ')
-        apt_packages = missing.values.map { |info| info[:apt] }.join(' ')
-        yum_packages = missing.values.map { |info| info[:yum] }.join(' ')
+        lib_names = missing.keys.join(", ")
+        apt_packages = missing.values.map { |info| info[:apt] }.join(" ")
+        yum_packages = missing.values.map { |info| info[:yum] }.join(" ")
 
         <<~MSG
           Missing required development libraries: #{lib_names}
@@ -359,7 +359,7 @@ module Kompo
     private
 
     def macos?
-      RUBY_PLATFORM.include?('darwin')
+      RUBY_PLATFORM.include?("darwin")
     end
   end
 end

--- a/lib/kompo/tasks/kompo_vfs_path.rb
+++ b/lib/kompo/tasks/kompo_vfs_path.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'fileutils'
-require_relative 'kompo_vfs_version_check'
+require "fileutils"
+require_relative "kompo_vfs_version_check"
 
 module Kompo
   # Section to get the kompo-vfs library path.
@@ -27,15 +27,15 @@ module Kompo
     class FromLocal < Taski::Task
       def run
         local_path = Taski.args[:local_kompo_vfs_path]
-        raise 'Local kompo-vfs path not specified' unless local_path
+        raise "Local kompo-vfs path not specified" unless local_path
         raise "Local kompo-vfs path does not exist: #{local_path}" unless Dir.exist?(local_path)
 
         puts "Building kompo-vfs from local directory: #{local_path}"
         cargo = CargoPath.path
 
-        raise 'Failed to build kompo-vfs' unless system(cargo, 'build', '--release', chdir: local_path)
+        raise "Failed to build kompo-vfs" unless system(cargo, "build", "--release", chdir: local_path)
 
-        @path = File.join(local_path, 'target', 'release')
+        @path = File.join(local_path, "target", "release")
         puts "kompo-vfs library path: #{@path}"
 
         KompoVfsVersionCheck.verify!(@path)
@@ -63,7 +63,7 @@ module Kompo
           unless missing_libs.empty?
             installed_version = `#{brew} list --versions kompo-vfs`.chomp.split.last
             raise "kompo-vfs #{installed_version} is outdated. Please run: brew upgrade kompo-vfs\n" \
-                  "Missing libraries: #{missing_libs.join(', ')}"
+                  "Missing libraries: #{missing_libs.join(", ")}"
           end
 
           puts "kompo-vfs library path: #{@path}"
@@ -76,9 +76,9 @@ module Kompo
       class Install < Taski::Task
         def run
           brew = HomebrewPath.path
-          puts 'Installing kompo-vfs via Homebrew...'
-          system(brew, 'tap', 'ahogappa/kompo') or raise 'Failed to tap ahogappa/kompo'
-          system(brew, 'install', 'kompo-vfs') or raise 'Failed to install kompo-vfs'
+          puts "Installing kompo-vfs via Homebrew..."
+          system(brew, "tap", "ahogappa/kompo") or raise "Failed to tap ahogappa/kompo"
+          system(brew, "install", "kompo-vfs") or raise "Failed to install kompo-vfs"
 
           @path = "#{`#{brew} --prefix kompo-vfs`.chomp}/lib"
           puts "kompo-vfs library path: #{@path}"
@@ -100,24 +100,24 @@ module Kompo
 
     # Build from source (requires Cargo)
     class FromSource < Taski::Task
-      REPO_URL = 'https://github.com/ahogappa/kompo-vfs'
+      REPO_URL = "https://github.com/ahogappa/kompo-vfs"
 
       def run
-        puts 'Building kompo-vfs from source...'
+        puts "Building kompo-vfs from source..."
         cargo = CargoPath.path
 
-        build_dir = File.expand_path('~/.kompo/kompo-vfs')
+        build_dir = File.expand_path("~/.kompo/kompo-vfs")
         FileUtils.mkdir_p(File.dirname(build_dir))
 
         if Dir.exist?(build_dir)
-          system('git', '-C', build_dir, 'pull', '--quiet')
+          system("git", "-C", build_dir, "pull", "--quiet")
         else
-          system('git', 'clone', REPO_URL, build_dir) or raise 'Failed to clone kompo-vfs repository'
+          system("git", "clone", REPO_URL, build_dir) or raise "Failed to clone kompo-vfs repository"
         end
 
-        system(cargo, 'build', '--release', chdir: build_dir) or raise 'Failed to build kompo-vfs'
+        system(cargo, "build", "--release", chdir: build_dir) or raise "Failed to build kompo-vfs"
 
-        @path = File.join(build_dir, 'target', 'release')
+        @path = File.join(build_dir, "target", "release")
         puts "kompo-vfs library path: #{@path}"
 
         KompoVfsVersionCheck.verify!(@path)

--- a/lib/kompo/tasks/kompo_vfs_version_check.rb
+++ b/lib/kompo/tasks/kompo_vfs_version_check.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../version'
+require_relative "../version"
 
 module Kompo
   # Verifies that the installed kompo-vfs version meets minimum requirements.
@@ -8,7 +8,7 @@ module Kompo
   module KompoVfsVersionCheck
     class IncompatibleVersionError < StandardError; end
 
-    VERSION_FILE = 'KOMPO_VFS_VERSION'
+    VERSION_FILE = "KOMPO_VFS_VERSION"
 
     def self.verify!(lib_path)
       actual_version = get_version(lib_path)

--- a/lib/kompo/tasks/make_fs_c.rb
+++ b/lib/kompo/tasks/make_fs_c.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'erb'
-require 'fileutils'
-require 'find'
+require "erb"
+require "fileutils"
+require "find"
 
 module Kompo
   # Struct to hold file data for embedding
@@ -30,7 +30,7 @@ module Kompo
 
     def run
       @work_dir = WorkDir.path
-      @path = File.join(@work_dir, 'fs.c')
+      @path = File.join(@work_dir, "fs.c")
 
       # Get original paths for Ruby standard library cache support
       # When Ruby is restored from cache, standard library paths are from the original build
@@ -48,7 +48,7 @@ module Kompo
       @paths = []
       @file_sizes = [0]
 
-      group('Collecting files') do
+      group("Collecting files") do
         embed_paths = collect_embed_paths
 
         embed_paths.each do |embed_path|
@@ -67,10 +67,10 @@ module Kompo
         puts "Collected #{@file_sizes.size - 1} files"
       end
 
-      group('Generating fs.c') do
+      group("Generating fs.c") do
         context = build_template_context
 
-        template_path = File.join(__dir__, '..', '..', 'fs.c.erb')
+        template_path = File.join(__dir__, "..", "..", "fs.c.erb")
         template = ERB.new(File.read(template_path))
         File.write(@path, template.result(binding))
         puts "Generated: fs.c (#{@file_bytes.size} bytes)"
@@ -81,7 +81,7 @@ module Kompo
       return unless @path && File.exist?(@path)
 
       FileUtils.rm_f(@path)
-      puts 'Cleaned up fs.c'
+      puts "Cleaned up fs.c"
     end
 
     private
@@ -97,8 +97,8 @@ module Kompo
       # 2. Gemfile, Gemfile.lock, and gemspec files (if exists)
       #    Created by: CopyGemfile
       if CopyGemfile.gemfile_exists
-        paths << File.join(@work_dir, 'Gemfile')
-        paths << File.join(@work_dir, 'Gemfile.lock')
+        paths << File.join(@work_dir, "Gemfile")
+        paths << File.join(@work_dir, "Gemfile.lock")
 
         # Include gemspec files for Bundler's gemspec directive
         paths += CopyGemfile.gemspec_paths
@@ -139,7 +139,7 @@ module Kompo
 
         # Skip certain file extensions
         next if SKIP_EXTENSIONS.any? { |ext| path.end_with?(ext) }
-        next if path.end_with?('selenium-manager')
+        next if path.end_with?("selenium-manager")
 
         # Skip files matching .kompoignore patterns
         next if should_ignore?(path)
@@ -157,7 +157,7 @@ module Kompo
       # Ruby standard library paths are outside work_dir and should not be filtered
       return false unless absolute_path.start_with?(@work_dir)
 
-      relative_path = absolute_path.sub("#{@work_dir}/", '')
+      relative_path = absolute_path.sub("#{@work_dir}/", "")
       if @kompo_ignore.ignore?(relative_path)
         puts "Ignoring (via .kompoignore): #{relative_path}"
         true
@@ -171,11 +171,11 @@ module Kompo
       # the same work_dir path is reused across builds via metadata.json
       # Ruby's $LOAD_PATH uses work_dir paths, so embedded files must match.
       embedded_path = if @current_ruby_install_dir != @original_ruby_install_dir && path.start_with?(@current_ruby_install_dir)
-                        # Ruby install dir path replacement for cache compatibility (when paths differ)
-                        path.sub(@current_ruby_install_dir, @original_ruby_install_dir)
-                      else
-                        path
-                      end
+        # Ruby install dir path replacement for cache compatibility (when paths differ)
+        path.sub(@current_ruby_install_dir, @original_ruby_install_dir)
+      else
+        path
+      end
 
       puts "#{path} -> #{embedded_path}" if path != embedded_path
 

--- a/lib/kompo/tasks/make_main_c.rb
+++ b/lib/kompo/tasks/make_main_c.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'erb'
-require 'fileutils'
+require "erb"
+require "fileutils"
 
 module Kompo
   # Generate main.c from ERB template
@@ -15,25 +15,25 @@ module Kompo
 
     def run
       work_dir = WorkDir.path
-      @path = File.join(work_dir, 'main.c')
+      @path = File.join(work_dir, "main.c")
 
       return if File.exist?(@path)
 
-      template_path = File.join(__dir__, '..', '..', 'main.c.erb')
+      template_path = File.join(__dir__, "..", "..", "main.c.erb")
       template = ERB.new(File.read(template_path))
 
       # Build context object for ERB template
       context = build_template_context
 
       File.write(@path, template.result(binding))
-      puts 'Generated: main.c'
+      puts "Generated: main.c"
     end
 
     def clean
       return unless @path && File.exist?(@path)
 
       FileUtils.rm_f(@path)
-      puts 'Cleaned up main.c'
+      puts "Cleaned up main.c"
     end
 
     private

--- a/lib/kompo/tasks/ruby_build_path.rb
+++ b/lib/kompo/tasks/ruby_build_path.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'open3'
+require "open3"
 
 module Kompo
   # Section to get the ruby-build path.
@@ -15,10 +15,10 @@ module Kompo
     # Use existing ruby-build installation
     class Installed < Taski::Task
       def run
-        path_output, = Open3.capture2('which', 'ruby-build', err: File::NULL)
+        path_output, = Open3.capture2("which", "ruby-build", err: File::NULL)
         @path = path_output.chomp
         puts "ruby-build path: #{@path}"
-        version_output, = Open3.capture2(@path, '--version', err: File::NULL)
+        version_output, = Open3.capture2(@path, "--version", err: File::NULL)
         puts "ruby-build version: #{version_output.chomp}"
       end
     end
@@ -26,20 +26,20 @@ module Kompo
     # Install ruby-build via git clone and return the path
     class Install < Taski::Task
       def run
-        puts 'ruby-build not found. Installing via git...'
-        install_dir = File.expand_path('~/.ruby-build')
+        puts "ruby-build not found. Installing via git..."
+        install_dir = File.expand_path("~/.ruby-build")
 
         if Dir.exist?(install_dir)
-          system('git', '-C', install_dir, 'pull', '--quiet')
+          system("git", "-C", install_dir, "pull", "--quiet")
         else
-          system('git', 'clone', 'https://github.com/rbenv/ruby-build.git', install_dir)
+          system("git", "clone", "https://github.com/rbenv/ruby-build.git", install_dir)
         end
 
-        @path = File.join(install_dir, 'bin', 'ruby-build')
-        raise 'Failed to install ruby-build' unless File.executable?(@path)
+        @path = File.join(install_dir, "bin", "ruby-build")
+        raise "Failed to install ruby-build" unless File.executable?(@path)
 
         puts "ruby-build installed at: #{@path}"
-        version_output, = Open3.capture2(@path, '--version', err: File::NULL)
+        version_output, = Open3.capture2(@path, "--version", err: File::NULL)
         puts "ruby-build version: #{version_output.chomp}"
       end
     end
@@ -47,7 +47,7 @@ module Kompo
     private
 
     def ruby_build_installed?
-      _, status = Open3.capture2('which', 'ruby-build', err: File::NULL)
+      _, status = Open3.capture2("which", "ruby-build", err: File::NULL)
       status.success?
     end
   end

--- a/lib/kompo/version.rb
+++ b/lib/kompo/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module Kompo
-  VERSION = '0.3.2'
-  KOMPO_VFS_MIN_VERSION = '0.5.0'
+  VERSION = "0.3.2"
+  KOMPO_VFS_MIN_VERSION = "0.5.0"
 end

--- a/test/cache_test.rb
+++ b/test/cache_test.rb
@@ -1,36 +1,36 @@
 # frozen_string_literal: true
 
-require_relative 'test_helper'
+require_relative "test_helper"
 
 class CacheTest < Minitest::Test
   def setup
-    @original_home = ENV['HOME']
+    @original_home = ENV["HOME"]
     @temp_home = Dir.mktmpdir
-    ENV['HOME'] = @temp_home
-    @cache_dir = File.join(@temp_home, '.kompo', 'cache')
+    ENV["HOME"] = @temp_home
+    @cache_dir = File.join(@temp_home, ".kompo", "cache")
   end
 
   def teardown
-    ENV['HOME'] = @original_home
+    ENV["HOME"] = @original_home
     FileUtils.rm_rf(@temp_home)
   end
 
   def test_clean_cache_no_directory
     assert_output(/Cache directory does not exist/) do
-      Kompo.clean_cache('3.4.1')
+      Kompo.clean_cache("3.4.1")
     end
   end
 
   def test_clean_cache_specific_version
     # New structure: ~/.kompo/cache/{version}/
-    version_dir = File.join(@cache_dir, '3.4.1')
-    FileUtils.mkdir_p(File.join(version_dir, 'ruby'))
-    File.write(File.join(version_dir, 'metadata.json'), '{}')
-    File.write(File.join(version_dir, 'ruby-3.4.1.tar.gz'), 'dummy tarball')
+    version_dir = File.join(@cache_dir, "3.4.1")
+    FileUtils.mkdir_p(File.join(version_dir, "ruby"))
+    File.write(File.join(version_dir, "metadata.json"), "{}")
+    File.write(File.join(version_dir, "ruby-3.4.1.tar.gz"), "dummy tarball")
 
     # Clean specific version
     assert_output(/Removed.*3\.4\.1.*Cache for Ruby 3\.4\.1 cleaned successfully/m) do
-      Kompo.clean_cache('3.4.1')
+      Kompo.clean_cache("3.4.1")
     end
 
     refute Dir.exist?(version_dir)
@@ -38,23 +38,23 @@ class CacheTest < Minitest::Test
 
   def test_clean_cache_specific_version_removes_all_contents
     # New structure: everything is under ~/.kompo/cache/{version}/
-    version_dir = File.join(@cache_dir, '3.4.1')
-    FileUtils.mkdir_p(File.join(version_dir, 'ruby'))
-    File.write(File.join(version_dir, 'metadata.json'), '{}')
-    File.write(File.join(version_dir, 'ruby-3.4.1.tar.gz'), 'dummy tarball')
+    version_dir = File.join(@cache_dir, "3.4.1")
+    FileUtils.mkdir_p(File.join(version_dir, "ruby"))
+    File.write(File.join(version_dir, "metadata.json"), "{}")
+    File.write(File.join(version_dir, "ruby-3.4.1.tar.gz"), "dummy tarball")
 
     # Bundle caches are also under the version directory
-    bundle_cache_dir = File.join(version_dir, 'bundle-abc123def456')
-    FileUtils.mkdir_p(File.join(bundle_cache_dir, 'bundle'))
-    FileUtils.mkdir_p(File.join(bundle_cache_dir, '.bundle'))
-    File.write(File.join(bundle_cache_dir, 'metadata.json'), '{}')
+    bundle_cache_dir = File.join(version_dir, "bundle-abc123def456")
+    FileUtils.mkdir_p(File.join(bundle_cache_dir, "bundle"))
+    FileUtils.mkdir_p(File.join(bundle_cache_dir, ".bundle"))
+    File.write(File.join(bundle_cache_dir, "metadata.json"), "{}")
 
-    bundle_cache_dir2 = File.join(version_dir, 'bundle-xyz789')
-    FileUtils.mkdir_p(File.join(bundle_cache_dir2, 'bundle'))
+    bundle_cache_dir2 = File.join(version_dir, "bundle-xyz789")
+    FileUtils.mkdir_p(File.join(bundle_cache_dir2, "bundle"))
 
     # Clean specific version - removes entire version directory
     assert_output(/Removed.*3\.4\.1.*Cache for Ruby 3\.4\.1 cleaned successfully/m) do
-      Kompo.clean_cache('3.4.1')
+      Kompo.clean_cache("3.4.1")
     end
 
     refute Dir.exist?(version_dir)
@@ -62,17 +62,17 @@ class CacheTest < Minitest::Test
 
   def test_clean_cache_specific_version_does_not_remove_other_version
     # Create version 3.4.1 cache
-    version_341 = File.join(@cache_dir, '3.4.1')
-    FileUtils.mkdir_p(File.join(version_341, 'ruby'))
-    FileUtils.mkdir_p(File.join(version_341, 'bundle-abc123'))
+    version_341 = File.join(@cache_dir, "3.4.1")
+    FileUtils.mkdir_p(File.join(version_341, "ruby"))
+    FileUtils.mkdir_p(File.join(version_341, "bundle-abc123"))
 
     # Create version 4.0.0 cache
-    version_400 = File.join(@cache_dir, '4.0.0')
-    FileUtils.mkdir_p(File.join(version_400, 'ruby'))
-    FileUtils.mkdir_p(File.join(version_400, 'bundle-xyz789'))
+    version_400 = File.join(@cache_dir, "4.0.0")
+    FileUtils.mkdir_p(File.join(version_400, "ruby"))
+    FileUtils.mkdir_p(File.join(version_400, "bundle-xyz789"))
 
     # Clean only 3.4.1
-    Kompo.clean_cache('3.4.1')
+    Kompo.clean_cache("3.4.1")
 
     # 3.4.1 should be removed
     refute Dir.exist?(version_341)
@@ -84,28 +84,28 @@ class CacheTest < Minitest::Test
     FileUtils.mkdir_p(@cache_dir)
 
     assert_output(/No cache found for Ruby 3\.4\.1/) do
-      Kompo.clean_cache('3.4.1')
+      Kompo.clean_cache("3.4.1")
     end
   end
 
   def test_clean_cache_all
     # Create multiple version caches
-    FileUtils.mkdir_p(File.join(@cache_dir, '3.4.1', 'ruby'))
-    FileUtils.mkdir_p(File.join(@cache_dir, '4.0.0', 'ruby'))
+    FileUtils.mkdir_p(File.join(@cache_dir, "3.4.1", "ruby"))
+    FileUtils.mkdir_p(File.join(@cache_dir, "4.0.0", "ruby"))
 
     # Clean all
     assert_output(/All caches cleaned successfully/) do
-      Kompo.clean_cache('all')
+      Kompo.clean_cache("all")
     end
 
-    assert_empty Dir.glob(File.join(@cache_dir, '*'))
+    assert_empty Dir.glob(File.join(@cache_dir, "*"))
   end
 
   def test_clean_cache_all_empty
     FileUtils.mkdir_p(@cache_dir)
 
     assert_output(/No caches found/) do
-      Kompo.clean_cache('all')
+      Kompo.clean_cache("all")
     end
   end
 end

--- a/test/kompo_ignore_test.rb
+++ b/test/kompo_ignore_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'test_helper'
+require_relative "test_helper"
 
 class KompoIgnoreTest < Minitest::Test
   def setup
@@ -14,7 +14,7 @@ class KompoIgnoreTest < Minitest::Test
   private
 
   def create_ignore_file(content)
-    File.write(File.join(@temp_dir, '.kompoignore'), content)
+    File.write(File.join(@temp_dir, ".kompoignore"), content)
     Kompo::KompoIgnore.new(@temp_dir)
   end
 
@@ -30,32 +30,32 @@ class KompoIgnoreTest < Minitest::Test
 
   def test_ignore_returns_false_when_not_enabled
     ignore = Kompo::KompoIgnore.new(@temp_dir)
-    refute ignore.ignore?('test.log')
+    refute ignore.ignore?("test.log")
   end
 
   def test_ignore_matches_simple_glob_pattern
     ignore = create_ignore_file("*.log\n")
 
-    assert ignore.ignore?('test.log')
-    assert ignore.ignore?('debug.log')
-    refute ignore.ignore?('test.rb')
+    assert ignore.ignore?("test.log")
+    assert ignore.ignore?("debug.log")
+    refute ignore.ignore?("test.rb")
   end
 
   def test_ignore_matches_directory_pattern
     ignore = create_ignore_file("tmp/\n")
 
-    assert ignore.ignore?('tmp/test.rb')
-    assert ignore.ignore?('tmp/cache/data.txt')
-    refute ignore.ignore?('src/tmp.rb')
+    assert ignore.ignore?("tmp/test.rb")
+    assert ignore.ignore?("tmp/cache/data.txt")
+    refute ignore.ignore?("src/tmp.rb")
   end
 
   def test_ignore_matches_double_star_pattern
     ignore = create_ignore_file("**/cache/\n")
 
-    assert ignore.ignore?('cache/data.txt')
-    assert ignore.ignore?('app/cache/data.txt')
-    assert ignore.ignore?('deep/nested/cache/data.txt')
-    refute ignore.ignore?('src/cached.rb')
+    assert ignore.ignore?("cache/data.txt")
+    assert ignore.ignore?("app/cache/data.txt")
+    assert ignore.ignore?("deep/nested/cache/data.txt")
+    refute ignore.ignore?("src/cached.rb")
   end
 
   def test_ignore_handles_negation_pattern
@@ -64,9 +64,9 @@ class KompoIgnoreTest < Minitest::Test
       !important.log
     IGNORE
 
-    assert ignore.ignore?('test.log')
-    assert ignore.ignore?('debug.log')
-    refute ignore.ignore?('important.log')
+    assert ignore.ignore?("test.log")
+    assert ignore.ignore?("debug.log")
+    refute ignore.ignore?("important.log")
   end
 
   def test_ignore_handles_comments
@@ -77,9 +77,9 @@ class KompoIgnoreTest < Minitest::Test
       tmp/
     IGNORE
 
-    assert ignore.ignore?('test.log')
-    assert ignore.ignore?('tmp/file.txt')
-    refute ignore.ignore?('test.rb')
+    assert ignore.ignore?("test.log")
+    assert ignore.ignore?("tmp/file.txt")
+    refute ignore.ignore?("test.rb")
   end
 
   def test_ignore_handles_empty_lines
@@ -90,8 +90,8 @@ class KompoIgnoreTest < Minitest::Test
 
     IGNORE
 
-    assert ignore.ignore?('test.log')
-    assert ignore.ignore?('tmp/file.txt')
+    assert ignore.ignore?("test.log")
+    assert ignore.ignore?("tmp/file.txt")
   end
 
   def test_ignore_multiple_patterns
@@ -103,18 +103,18 @@ class KompoIgnoreTest < Minitest::Test
       test/
     IGNORE
 
-    assert ignore.ignore?('debug.log')
-    assert ignore.ignore?('cache.tmp')
-    assert ignore.ignore?('node_modules/package.json')
-    assert ignore.ignore?('spec/test_spec.rb')
-    assert ignore.ignore?('test/test_file.rb')
-    refute ignore.ignore?('app/main.rb')
+    assert ignore.ignore?("debug.log")
+    assert ignore.ignore?("cache.tmp")
+    assert ignore.ignore?("node_modules/package.json")
+    assert ignore.ignore?("spec/test_spec.rb")
+    assert ignore.ignore?("test/test_file.rb")
+    refute ignore.ignore?("app/main.rb")
   end
 
   def test_ignore_handles_path_with_leading_slash
     ignore = create_ignore_file("/config.local.yml\n")
 
-    assert ignore.ignore?('config.local.yml')
-    refute ignore.ignore?('subdir/config.local.yml')
+    assert ignore.ignore?("config.local.yml")
+    refute ignore.ignore?("subdir/config.local.yml")
   end
 end

--- a/test/tasks/bundle_install_test.rb
+++ b/test/tasks/bundle_install_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../test_helper'
+require_relative "../test_helper"
 
 class BundleInstallTest < Minitest::Test
   include Taski::TestHelper::Minitest
@@ -8,14 +8,14 @@ class BundleInstallTest < Minitest::Test
 
   def test_bundle_install_skips_when_no_gemfile
     Dir.mktmpdir do |tmpdir|
-      work_dir = File.join(tmpdir, 'work')
+      work_dir = File.join(tmpdir, "work")
       FileUtils.mkdir_p(work_dir)
 
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
       mock_task(Kompo::CopyGemfile, gemfile_exists: false)
       mock_task(Kompo::InstallRuby,
-                bundler_path: '/path/to/bundler',
-                ruby_major_minor: '3.4')
+        bundler_path: "/path/to/bundler",
+        ruby_major_minor: "3.4")
 
       bundle_ruby_dir = Kompo::BundleInstall.bundle_ruby_dir
       bundler_config_path = Kompo::BundleInstall.bundler_config_path
@@ -28,26 +28,26 @@ class BundleInstallTest < Minitest::Test
 
   def test_bundle_install_sets_paths_when_gemfile_exists
     Dir.mktmpdir do |tmpdir|
-      work_dir = File.join(tmpdir, 'work')
+      work_dir = File.join(tmpdir, "work")
       FileUtils.mkdir_p(work_dir)
-      File.write(File.join(work_dir, 'Gemfile'), "source 'https://rubygems.org'")
-      File.write(File.join(work_dir, 'Gemfile.lock'), "GEM\n  specs:\n")
+      File.write(File.join(work_dir, "Gemfile"), "source 'https://rubygems.org'")
+      File.write(File.join(work_dir, "Gemfile.lock"), "GEM\n  specs:\n")
 
       # Create bundle directory that would be created by bundle install
-      bundle_dir = File.join(work_dir, 'bundle', 'ruby', '3.4.0')
-      bundle_config_dir = File.join(work_dir, '.bundle')
+      bundle_dir = File.join(work_dir, "bundle", "ruby", "3.4.0")
+      bundle_config_dir = File.join(work_dir, ".bundle")
       FileUtils.mkdir_p(bundle_dir)
       FileUtils.mkdir_p(bundle_config_dir)
-      File.write(File.join(bundle_config_dir, 'config'), 'BUNDLE_PATH: bundle')
+      File.write(File.join(bundle_config_dir, "config"), "BUNDLE_PATH: bundle")
 
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
       mock_task(Kompo::CopyGemfile, gemfile_exists: true)
       mock_task(Kompo::InstallRuby,
-                bundler_path: '/path/to/bundler',
-                ruby_path: '/path/to/ruby',
-                ruby_version: '3.4.1',
-                ruby_major_minor: '3.4')
-      mock_args(kompo_cache: File.join(tmpdir, '.kompo', 'cache'))
+        bundler_path: "/path/to/bundler",
+        ruby_path: "/path/to/ruby",
+        ruby_version: "3.4.1",
+        ruby_major_minor: "3.4")
+      mock_args(kompo_cache: File.join(tmpdir, ".kompo", "cache"))
 
       # Stub system calls to avoid actual bundle install
       Kompo::BundleInstall::FromSource.define_method(:system) do |*_args, **_kwargs|
@@ -58,8 +58,8 @@ class BundleInstallTest < Minitest::Test
         bundle_ruby_dir = Kompo::BundleInstall.bundle_ruby_dir
         bundler_config_path = Kompo::BundleInstall.bundler_config_path
 
-        assert_equal File.join(work_dir, 'bundle', 'ruby', '3.4.0'), bundle_ruby_dir
-        assert_equal File.join(work_dir, '.bundle', 'config'), bundler_config_path
+        assert_equal File.join(work_dir, "bundle", "ruby", "3.4.0"), bundle_ruby_dir
+        assert_equal File.join(work_dir, ".bundle", "config"), bundler_config_path
       ensure
         Kompo::BundleInstall::FromSource.remove_method(:system)
       end
@@ -89,39 +89,39 @@ class BundleInstallTest < Minitest::Test
 
   def test_bundle_install_from_cache_restores_bundle_directory
     Dir.mktmpdir do |tmpdir|
-      work_dir = File.join(tmpdir, 'work')
+      work_dir = File.join(tmpdir, "work")
       FileUtils.mkdir_p(work_dir)
       gemfile_lock_content = "GEM\n  specs:\n"
-      File.write(File.join(work_dir, 'Gemfile.lock'), gemfile_lock_content)
+      File.write(File.join(work_dir, "Gemfile.lock"), gemfile_lock_content)
 
       # Calculate expected cache name (new structure: {version}/bundle-{hash})
       hash = Digest::SHA256.hexdigest(gemfile_lock_content)[0..15]
       bundle_cache_name = "bundle-#{hash}"
-      version_cache_dir = File.join(tmpdir, '.kompo', 'cache', '3.4.1')
+      version_cache_dir = File.join(tmpdir, ".kompo", "cache", "3.4.1")
       cache_dir = File.join(version_cache_dir, bundle_cache_name)
 
       # Create cache with content
-      cache_bundle_dir = File.join(cache_dir, 'bundle', 'ruby', '3.4.0', 'gems', 'sinatra-4.0.0')
-      cache_bundle_lib_dir = File.join(cache_bundle_dir, 'lib')
-      cache_bundle_config = File.join(cache_dir, '.bundle')
+      cache_bundle_dir = File.join(cache_dir, "bundle", "ruby", "3.4.0", "gems", "sinatra-4.0.0")
+      cache_bundle_lib_dir = File.join(cache_bundle_dir, "lib")
+      cache_bundle_config = File.join(cache_dir, ".bundle")
       FileUtils.mkdir_p(cache_bundle_lib_dir)
       FileUtils.mkdir_p(cache_bundle_config)
-      File.write(File.join(cache_bundle_lib_dir, 'sinatra.rb'), '# sinatra gem')
-      File.write(File.join(cache_bundle_config, 'config'), 'BUNDLE_PATH: bundle')
-      File.write(File.join(cache_dir, 'metadata.json'), '{"ruby_version": "3.4.1"}')
+      File.write(File.join(cache_bundle_lib_dir, "sinatra.rb"), "# sinatra gem")
+      File.write(File.join(cache_bundle_config, "config"), "BUNDLE_PATH: bundle")
+      File.write(File.join(cache_dir, "metadata.json"), '{"ruby_version": "3.4.1"}')
 
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
       mock_task(Kompo::CopyGemfile, gemfile_exists: true)
-      mock_task(Kompo::InstallRuby, ruby_version: '3.4.1', ruby_major_minor: '3.4')
-      mock_args(kompo_cache: File.join(tmpdir, '.kompo', 'cache'))
+      mock_task(Kompo::InstallRuby, ruby_version: "3.4.1", ruby_major_minor: "3.4")
+      mock_args(kompo_cache: File.join(tmpdir, ".kompo", "cache"))
 
       bundle_ruby_dir = Kompo::BundleInstall.bundle_ruby_dir
 
       # Verify cache was restored
-      assert Dir.exist?(File.join(work_dir, 'bundle'))
-      assert Dir.exist?(File.join(work_dir, '.bundle'))
-      assert File.exist?(File.join(work_dir, '.bundle', 'config'))
-      assert_equal File.join(work_dir, 'bundle', 'ruby', '3.4.0'), bundle_ruby_dir
+      assert Dir.exist?(File.join(work_dir, "bundle"))
+      assert Dir.exist?(File.join(work_dir, ".bundle"))
+      assert File.exist?(File.join(work_dir, ".bundle", "config"))
+      assert_equal File.join(work_dir, "bundle", "ruby", "3.4.0"), bundle_ruby_dir
     end
   end
 
@@ -130,27 +130,27 @@ class BundleInstallTest < Minitest::Test
       # Resolve tmpdir to real path (macOS /var -> /private/var symlink)
       tmpdir = File.realpath(tmpdir)
 
-      work_dir = File.join(tmpdir, 'work')
+      work_dir = File.join(tmpdir, "work")
       FileUtils.mkdir_p(work_dir)
       gemfile_lock_content = "GEM\n  specs:\n"
-      File.write(File.join(work_dir, 'Gemfile'), "source 'https://rubygems.org'")
-      File.write(File.join(work_dir, 'Gemfile.lock'), gemfile_lock_content)
+      File.write(File.join(work_dir, "Gemfile"), "source 'https://rubygems.org'")
+      File.write(File.join(work_dir, "Gemfile.lock"), gemfile_lock_content)
 
       # Create bundle directory that would be created by bundle install
-      bundle_dir = File.join(work_dir, 'bundle', 'ruby', '3.4.0', 'gems')
-      bundle_config_dir = File.join(work_dir, '.bundle')
+      bundle_dir = File.join(work_dir, "bundle", "ruby", "3.4.0", "gems")
+      bundle_config_dir = File.join(work_dir, ".bundle")
       FileUtils.mkdir_p(bundle_dir)
       FileUtils.mkdir_p(bundle_config_dir)
-      File.write(File.join(bundle_config_dir, 'config'), 'BUNDLE_PATH: bundle')
+      File.write(File.join(bundle_config_dir, "config"), "BUNDLE_PATH: bundle")
 
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
       mock_task(Kompo::CopyGemfile, gemfile_exists: true)
       mock_task(Kompo::InstallRuby,
-                ruby_version: '3.4.1',
-                ruby_major_minor: '3.4',
-                ruby_path: '/path/to/ruby',
-                bundler_path: '/path/to/bundler')
-      mock_args(kompo_cache: File.join(tmpdir, '.kompo', 'cache'))
+        ruby_version: "3.4.1",
+        ruby_major_minor: "3.4",
+        ruby_path: "/path/to/ruby",
+        bundler_path: "/path/to/bundler")
+      mock_args(kompo_cache: File.join(tmpdir, ".kompo", "cache"))
 
       # Stub system calls
       Kompo::BundleInstall::FromSource.define_method(:system) do |*_args, **_kwargs|
@@ -163,18 +163,18 @@ class BundleInstallTest < Minitest::Test
         # Verify cache was created (new structure: {version}/bundle-{hash})
         hash = Digest::SHA256.hexdigest(gemfile_lock_content)[0..15]
         bundle_cache_name = "bundle-#{hash}"
-        version_cache_dir = File.join(tmpdir, '.kompo', 'cache', '3.4.1')
+        version_cache_dir = File.join(tmpdir, ".kompo", "cache", "3.4.1")
         cache_dir = File.join(version_cache_dir, bundle_cache_name)
 
-        assert Dir.exist?(cache_dir), 'Cache directory should exist'
-        assert Dir.exist?(File.join(cache_dir, 'bundle')), 'Cache bundle directory should exist'
-        assert Dir.exist?(File.join(cache_dir, '.bundle')), 'Cache .bundle directory should exist'
-        assert File.exist?(File.join(cache_dir, 'metadata.json')), 'Cache metadata should exist'
+        assert Dir.exist?(cache_dir), "Cache directory should exist"
+        assert Dir.exist?(File.join(cache_dir, "bundle")), "Cache bundle directory should exist"
+        assert Dir.exist?(File.join(cache_dir, ".bundle")), "Cache .bundle directory should exist"
+        assert File.exist?(File.join(cache_dir, "metadata.json")), "Cache metadata should exist"
 
         # Verify metadata content
-        metadata = JSON.parse(File.read(File.join(cache_dir, 'metadata.json')))
-        assert_equal '3.4.1', metadata['ruby_version']
-        assert_equal hash, metadata['gemfile_lock_hash']
+        metadata = JSON.parse(File.read(File.join(cache_dir, "metadata.json")))
+        assert_equal "3.4.1", metadata["ruby_version"]
+        assert_equal hash, metadata["gemfile_lock_hash"]
       ensure
         Kompo::BundleInstall::FromSource.remove_method(:system)
       end

--- a/test/tasks/check_stdlibs_test.rb
+++ b/test/tasks/check_stdlibs_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../test_helper'
+require_relative "../test_helper"
 
 class CheckStdlibsTest < Minitest::Test
   include Taski::TestHelper::Minitest
@@ -8,7 +8,7 @@ class CheckStdlibsTest < Minitest::Test
 
   def test_check_stdlibs_accesses_install_ruby
     Dir.mktmpdir do |tmpdir|
-      stdlib_root = File.join(tmpdir, 'lib', 'ruby', '3.4.0')
+      stdlib_root = File.join(tmpdir, "lib", "ruby", "3.4.0")
       FileUtils.mkdir_p(stdlib_root)
       mock_install_ruby_with_dir(tmpdir)
 
@@ -21,7 +21,7 @@ class CheckStdlibsTest < Minitest::Test
 
   def test_check_stdlibs_skips_when_no_stdlib_flag_set
     Dir.mktmpdir do |tmpdir|
-      stdlib_root = File.join(tmpdir, 'lib', 'ruby', '3.4.0')
+      stdlib_root = File.join(tmpdir, "lib", "ruby", "3.4.0")
       FileUtils.mkdir_p(stdlib_root)
       mock_install_ruby_with_dir(tmpdir)
       mock_args(no_stdlib: true)
@@ -34,8 +34,8 @@ class CheckStdlibsTest < Minitest::Test
 
   def test_check_stdlibs_includes_gem_specifications
     Dir.mktmpdir do |tmpdir|
-      stdlib_root = File.join(tmpdir, 'lib', 'ruby', '3.4.0')
-      gems_specs = File.join(tmpdir, 'lib', 'ruby', 'gems', '3.4.0', 'specifications')
+      stdlib_root = File.join(tmpdir, "lib", "ruby", "3.4.0")
+      gems_specs = File.join(tmpdir, "lib", "ruby", "gems", "3.4.0", "specifications")
       FileUtils.mkdir_p([stdlib_root, gems_specs])
       mock_install_ruby_with_dir(tmpdir)
 
@@ -50,9 +50,9 @@ class CheckStdlibsTest < Minitest::Test
 
   def mock_install_ruby_with_dir(dir)
     mock_task(Kompo::InstallRuby,
-              ruby_path: '/path/to/ruby',
-              ruby_install_dir: dir,
-              original_ruby_install_dir: dir,
-              ruby_major_minor: '3.4')
+      ruby_path: "/path/to/ruby",
+      ruby_install_dir: dir,
+      original_ruby_install_dir: dir,
+      ruby_major_minor: "3.4")
   end
 end

--- a/test/tasks/collect_dependencies_test.rb
+++ b/test/tasks/collect_dependencies_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../test_helper'
+require_relative "../test_helper"
 
 class CollectDependenciesTest < Minitest::Test
   include Taski::TestHelper::Minitest
@@ -8,50 +8,50 @@ class CollectDependenciesTest < Minitest::Test
 
   def test_collect_dependencies_output_path_in_directory
     Dir.mktmpdir do |tmpdir|
-      work_dir = File.join(tmpdir, 'work')
-      project_dir = File.join(tmpdir, 'myproject')
-      output_dir = File.join(tmpdir, 'output')
+      work_dir = File.join(tmpdir, "work")
+      project_dir = File.join(tmpdir, "myproject")
+      output_dir = File.join(tmpdir, "output")
       FileUtils.mkdir_p([work_dir, project_dir, output_dir])
 
       # Mock all dependencies
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
       mock_task(Kompo::InstallRuby,
-                ruby_install_dir: '/path/to/install',
-                ruby_version: '3.4.1',
-                ruby_major_minor: '3.4',
-                ruby_build_path: '/path/to/build')
-      mock_task(Kompo::KompoVfsPath, path: '/path/to/kompo_lib')
-      mock_task(Kompo::MakeMainC, path: File.join(work_dir, 'main.c'))
-      mock_task(Kompo::MakeFsC, path: File.join(work_dir, 'fs.c'))
+        ruby_install_dir: "/path/to/install",
+        ruby_version: "3.4.1",
+        ruby_major_minor: "3.4",
+        ruby_build_path: "/path/to/build")
+      mock_task(Kompo::KompoVfsPath, path: "/path/to/kompo_lib")
+      mock_task(Kompo::MakeMainC, path: File.join(work_dir, "main.c"))
+      mock_task(Kompo::MakeFsC, path: File.join(work_dir, "fs.c"))
       mock_task(Kompo::BuildNativeGem, exts_dir: nil, exts: [])
-      mock_task(Kompo::InstallDeps, lib_paths: '')
+      mock_task(Kompo::InstallDeps, lib_paths: "")
       mock_args(project_dir: project_dir, output_dir: output_dir)
 
       output_path = Kompo::CollectDependencies.output_path
 
       # Output should be in output_dir with project name
-      assert_equal File.join(output_dir, 'myproject'), output_path
+      assert_equal File.join(output_dir, "myproject"), output_path
     end
   end
 
   def test_collect_dependencies_output_path_as_file
     Dir.mktmpdir do |tmpdir|
-      work_dir = File.join(tmpdir, 'work')
-      project_dir = File.join(tmpdir, 'myproject')
-      output_file = File.join(tmpdir, 'mybinary')
+      work_dir = File.join(tmpdir, "work")
+      project_dir = File.join(tmpdir, "myproject")
+      output_file = File.join(tmpdir, "mybinary")
       FileUtils.mkdir_p([work_dir, project_dir])
 
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
       mock_task(Kompo::InstallRuby,
-                ruby_install_dir: '/path/to/install',
-                ruby_version: '3.4.1',
-                ruby_major_minor: '3.4',
-                ruby_build_path: '/path/to/build')
-      mock_task(Kompo::KompoVfsPath, path: '/path/to/kompo_lib')
-      mock_task(Kompo::MakeMainC, path: File.join(work_dir, 'main.c'))
-      mock_task(Kompo::MakeFsC, path: File.join(work_dir, 'fs.c'))
+        ruby_install_dir: "/path/to/install",
+        ruby_version: "3.4.1",
+        ruby_major_minor: "3.4",
+        ruby_build_path: "/path/to/build")
+      mock_task(Kompo::KompoVfsPath, path: "/path/to/kompo_lib")
+      mock_task(Kompo::MakeMainC, path: File.join(work_dir, "main.c"))
+      mock_task(Kompo::MakeFsC, path: File.join(work_dir, "fs.c"))
       mock_task(Kompo::BuildNativeGem, exts_dir: nil, exts: [])
-      mock_task(Kompo::InstallDeps, lib_paths: '')
+      mock_task(Kompo::InstallDeps, lib_paths: "")
       mock_args(project_dir: project_dir, output_dir: output_file)
 
       output_path = Kompo::CollectDependencies.output_path
@@ -63,36 +63,36 @@ class CollectDependenciesTest < Minitest::Test
 
   def test_collect_dependencies_collects_all_dependencies
     Dir.mktmpdir do |tmpdir|
-      work_dir = File.join(tmpdir, 'work')
-      project_dir = File.join(tmpdir, 'myproject')
-      output_dir = File.join(tmpdir, 'output')
+      work_dir = File.join(tmpdir, "work")
+      project_dir = File.join(tmpdir, "myproject")
+      output_dir = File.join(tmpdir, "output")
       FileUtils.mkdir_p([work_dir, project_dir, output_dir])
 
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
       mock_task(Kompo::InstallRuby,
-                ruby_install_dir: '/test/install',
-                ruby_version: '3.4.1',
-                ruby_major_minor: '3.4',
-                ruby_build_path: '/test/build')
-      mock_task(Kompo::KompoVfsPath, path: '/test/kompo_lib')
-      mock_task(Kompo::MakeMainC, path: '/test/main.c')
-      mock_task(Kompo::MakeFsC, path: '/test/fs.c')
-      mock_task(Kompo::BuildNativeGem, exts_dir: '/test/exts', exts: ['ext1'])
-      mock_task(Kompo::InstallDeps, lib_paths: '')
+        ruby_install_dir: "/test/install",
+        ruby_version: "3.4.1",
+        ruby_major_minor: "3.4",
+        ruby_build_path: "/test/build")
+      mock_task(Kompo::KompoVfsPath, path: "/test/kompo_lib")
+      mock_task(Kompo::MakeMainC, path: "/test/main.c")
+      mock_task(Kompo::MakeFsC, path: "/test/fs.c")
+      mock_task(Kompo::BuildNativeGem, exts_dir: "/test/exts", exts: ["ext1"])
+      mock_task(Kompo::InstallDeps, lib_paths: "")
       mock_args(project_dir: project_dir, output_dir: output_dir)
 
       # Access deps through exported value
       deps = Kompo::CollectDependencies.deps
 
       # Verify all dependencies were collected
-      assert_equal '/test/install', deps.ruby_install_dir
-      assert_equal '3.4.1', deps.ruby_version
-      assert_equal '3.4', deps.ruby_major_minor
-      assert_equal '/test/build', deps.ruby_build_path
-      assert_equal '/test/kompo_lib', deps.kompo_lib
-      assert_equal '/test/main.c', deps.main_c
-      assert_equal '/test/fs.c', deps.fs_c
-      assert_equal '/test/exts', deps.exts_dir
+      assert_equal "/test/install", deps.ruby_install_dir
+      assert_equal "3.4.1", deps.ruby_version
+      assert_equal "3.4", deps.ruby_major_minor
+      assert_equal "/test/build", deps.ruby_build_path
+      assert_equal "/test/kompo_lib", deps.kompo_lib
+      assert_equal "/test/main.c", deps.main_c
+      assert_equal "/test/fs.c", deps.fs_c
+      assert_equal "/test/exts", deps.exts_dir
 
       # Verify dependent tasks were accessed
       assert_task_accessed(Kompo::InstallRuby, :ruby_install_dir)

--- a/test/tasks/copy_files_test.rb
+++ b/test/tasks/copy_files_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../test_helper'
+require_relative "../test_helper"
 
 class CopyGemfileTest < Minitest::Test
   include Taski::TestHelper::Minitest
@@ -8,8 +8,8 @@ class CopyGemfileTest < Minitest::Test
 
   def test_copy_gemfile_returns_false_when_no_gemfile
     Dir.mktmpdir do |tmpdir|
-      work_dir = File.join(tmpdir, 'work')
-      project_dir = File.join(tmpdir, 'project')
+      work_dir = File.join(tmpdir, "work")
+      project_dir = File.join(tmpdir, "project")
       FileUtils.mkdir_p([work_dir, project_dir])
       # No Gemfile in project_dir
 
@@ -22,105 +22,105 @@ class CopyGemfileTest < Minitest::Test
 
   def test_copy_gemfile_returns_true_when_gemfile_exists
     Dir.mktmpdir do |tmpdir|
-      work_dir = File.join(tmpdir, 'work')
-      project_dir = File.join(tmpdir, 'project')
+      work_dir = File.join(tmpdir, "work")
+      project_dir = File.join(tmpdir, "project")
       FileUtils.mkdir_p([work_dir, project_dir])
       # Create Gemfile in project_dir
-      File.write(File.join(project_dir, 'Gemfile'), "source 'https://rubygems.org'")
+      File.write(File.join(project_dir, "Gemfile"), "source 'https://rubygems.org'")
 
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
       mock_args(project_dir: project_dir)
 
       assert Kompo::CopyGemfile.gemfile_exists
       # Verify Gemfile was copied to work_dir
-      assert File.exist?(File.join(work_dir, 'Gemfile'))
+      assert File.exist?(File.join(work_dir, "Gemfile"))
     end
   end
 
   def test_copy_gemfile_also_copies_gemfile_lock
     Dir.mktmpdir do |tmpdir|
-      work_dir = File.join(tmpdir, 'work')
-      project_dir = File.join(tmpdir, 'project')
+      work_dir = File.join(tmpdir, "work")
+      project_dir = File.join(tmpdir, "project")
       FileUtils.mkdir_p([work_dir, project_dir])
       # Create both Gemfile and Gemfile.lock in project_dir
-      File.write(File.join(project_dir, 'Gemfile'), "source 'https://rubygems.org'")
-      File.write(File.join(project_dir, 'Gemfile.lock'), "GEM\n  remote: https://rubygems.org/\n")
+      File.write(File.join(project_dir, "Gemfile"), "source 'https://rubygems.org'")
+      File.write(File.join(project_dir, "Gemfile.lock"), "GEM\n  remote: https://rubygems.org/\n")
 
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
       mock_args(project_dir: project_dir)
 
       assert Kompo::CopyGemfile.gemfile_exists
       # Verify both files were copied to work_dir
-      assert File.exist?(File.join(work_dir, 'Gemfile'))
-      assert File.exist?(File.join(work_dir, 'Gemfile.lock'))
+      assert File.exist?(File.join(work_dir, "Gemfile"))
+      assert File.exist?(File.join(work_dir, "Gemfile.lock"))
     end
   end
 
   def test_copy_gemfile_copies_gemspec_when_gemfile_references_gemspec
     Dir.mktmpdir do |tmpdir|
-      work_dir = File.join(tmpdir, 'work')
-      project_dir = File.join(tmpdir, 'project')
+      work_dir = File.join(tmpdir, "work")
+      project_dir = File.join(tmpdir, "project")
       FileUtils.mkdir_p([work_dir, project_dir])
       # Create Gemfile with gemspec directive
-      File.write(File.join(project_dir, 'Gemfile'), "source 'https://rubygems.org'\ngemspec")
-      File.write(File.join(project_dir, 'my_gem.gemspec'), "Gem::Specification.new { |s| s.name = 'my_gem' }")
+      File.write(File.join(project_dir, "Gemfile"), "source 'https://rubygems.org'\ngemspec")
+      File.write(File.join(project_dir, "my_gem.gemspec"), "Gem::Specification.new { |s| s.name = 'my_gem' }")
 
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
       mock_args(project_dir: project_dir)
 
       assert Kompo::CopyGemfile.gemfile_exists
       # Verify Gemfile and gemspec were copied to work_dir
-      assert File.exist?(File.join(work_dir, 'Gemfile'))
-      assert File.exist?(File.join(work_dir, 'my_gem.gemspec'))
+      assert File.exist?(File.join(work_dir, "Gemfile"))
+      assert File.exist?(File.join(work_dir, "my_gem.gemspec"))
     end
   end
 
   def test_copy_gemfile_does_not_copy_gemspec_when_no_gemspec_directive
     Dir.mktmpdir do |tmpdir|
-      work_dir = File.join(tmpdir, 'work')
-      project_dir = File.join(tmpdir, 'project')
+      work_dir = File.join(tmpdir, "work")
+      project_dir = File.join(tmpdir, "project")
       FileUtils.mkdir_p([work_dir, project_dir])
       # Create Gemfile without gemspec directive
-      File.write(File.join(project_dir, 'Gemfile'), "source 'https://rubygems.org'\ngem 'rake'")
-      File.write(File.join(project_dir, 'my_gem.gemspec'), "Gem::Specification.new { |s| s.name = 'my_gem' }")
+      File.write(File.join(project_dir, "Gemfile"), "source 'https://rubygems.org'\ngem 'rake'")
+      File.write(File.join(project_dir, "my_gem.gemspec"), "Gem::Specification.new { |s| s.name = 'my_gem' }")
 
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
       mock_args(project_dir: project_dir)
 
       assert Kompo::CopyGemfile.gemfile_exists
       # Verify Gemfile was copied but gemspec was not
-      assert File.exist?(File.join(work_dir, 'Gemfile'))
-      refute File.exist?(File.join(work_dir, 'my_gem.gemspec'))
+      assert File.exist?(File.join(work_dir, "Gemfile"))
+      refute File.exist?(File.join(work_dir, "my_gem.gemspec"))
     end
   end
 
   def test_copy_gemfile_copies_multiple_gemspecs
     Dir.mktmpdir do |tmpdir|
-      work_dir = File.join(tmpdir, 'work')
-      project_dir = File.join(tmpdir, 'project')
+      work_dir = File.join(tmpdir, "work")
+      project_dir = File.join(tmpdir, "project")
       FileUtils.mkdir_p([work_dir, project_dir])
       # Create Gemfile with gemspec directive and multiple gemspecs
-      File.write(File.join(project_dir, 'Gemfile'), "gemspec")
-      File.write(File.join(project_dir, 'my_gem.gemspec'), "Gem::Specification.new { |s| s.name = 'my_gem' }")
-      File.write(File.join(project_dir, 'other_gem.gemspec'), "Gem::Specification.new { |s| s.name = 'other_gem' }")
+      File.write(File.join(project_dir, "Gemfile"), "gemspec")
+      File.write(File.join(project_dir, "my_gem.gemspec"), "Gem::Specification.new { |s| s.name = 'my_gem' }")
+      File.write(File.join(project_dir, "other_gem.gemspec"), "Gem::Specification.new { |s| s.name = 'other_gem' }")
 
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
       mock_args(project_dir: project_dir)
 
       assert Kompo::CopyGemfile.gemfile_exists
       # Verify all gemspecs were copied
-      assert File.exist?(File.join(work_dir, 'my_gem.gemspec'))
-      assert File.exist?(File.join(work_dir, 'other_gem.gemspec'))
+      assert File.exist?(File.join(work_dir, "my_gem.gemspec"))
+      assert File.exist?(File.join(work_dir, "other_gem.gemspec"))
     end
   end
 
   def test_copy_gemfile_skips_when_no_gemfile_option_specified
     Dir.mktmpdir do |tmpdir|
-      work_dir = File.join(tmpdir, 'work')
-      project_dir = File.join(tmpdir, 'project')
+      work_dir = File.join(tmpdir, "work")
+      project_dir = File.join(tmpdir, "project")
       FileUtils.mkdir_p([work_dir, project_dir])
       # Create Gemfile in project_dir
-      File.write(File.join(project_dir, 'Gemfile'), "source 'https://rubygems.org'")
+      File.write(File.join(project_dir, "Gemfile"), "source 'https://rubygems.org'")
 
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
       mock_args(project_dir: project_dir, no_gemfile: true)
@@ -128,7 +128,7 @@ class CopyGemfileTest < Minitest::Test
       # gemfile_exists should be false even though Gemfile exists
       refute Kompo::CopyGemfile.gemfile_exists
       # Verify Gemfile was NOT copied to work_dir
-      refute File.exist?(File.join(work_dir, 'Gemfile'))
+      refute File.exist?(File.join(work_dir, "Gemfile"))
     end
   end
 end
@@ -139,20 +139,20 @@ class CopyProjectFilesTest < Minitest::Test
 
   def test_copy_project_files_copies_entrypoint
     Dir.mktmpdir do |tmpdir|
-      work_dir = File.join(tmpdir, 'work')
-      project_dir = File.join(tmpdir, 'project')
+      work_dir = File.join(tmpdir, "work")
+      project_dir = File.join(tmpdir, "project")
       FileUtils.mkdir_p([work_dir, project_dir])
 
       # Create entrypoint in project_dir
-      File.write(File.join(project_dir, 'main.rb'), "puts 'hello'")
+      File.write(File.join(project_dir, "main.rb"), "puts 'hello'")
 
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
-      mock_args(project_dir: project_dir, entrypoint: 'main.rb', files: [])
+      mock_args(project_dir: project_dir, entrypoint: "main.rb", files: [])
 
       entrypoint_path = Kompo::CopyProjectFiles.entrypoint_path
       additional_paths = Kompo::CopyProjectFiles.additional_paths
 
-      assert_equal File.join(work_dir, 'main.rb'), entrypoint_path
+      assert_equal File.join(work_dir, "main.rb"), entrypoint_path
       assert_equal [], additional_paths
       # Verify file was copied
       assert File.exist?(entrypoint_path)
@@ -164,25 +164,25 @@ class CopyProjectFilesTest < Minitest::Test
     Dir.mktmpdir do |tmpdir|
       # Use realpath to match WorkDir behavior (resolves symlinks like /tmp -> /private/tmp on macOS)
       tmpdir = File.realpath(tmpdir)
-      work_dir = File.join(tmpdir, 'work')
-      project_dir = File.join(tmpdir, 'project')
-      lib_dir = File.join(project_dir, 'lib')
+      work_dir = File.join(tmpdir, "work")
+      project_dir = File.join(tmpdir, "project")
+      lib_dir = File.join(project_dir, "lib")
       FileUtils.mkdir_p([work_dir, lib_dir])
 
       # Create files in project_dir
-      File.write(File.join(project_dir, 'main.rb'), "require_relative 'lib/app'")
-      File.write(File.join(lib_dir, 'app.rb'), 'class App; end')
+      File.write(File.join(project_dir, "main.rb"), "require_relative 'lib/app'")
+      File.write(File.join(lib_dir, "app.rb"), "class App; end")
 
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
-      mock_args(project_dir: project_dir, entrypoint: 'main.rb', files: ['lib'])
+      mock_args(project_dir: project_dir, entrypoint: "main.rb", files: ["lib"])
 
       entrypoint_path = Kompo::CopyProjectFiles.entrypoint_path
       additional_paths = Kompo::CopyProjectFiles.additional_paths
 
-      assert_equal File.join(work_dir, 'main.rb'), entrypoint_path
-      assert_includes additional_paths, File.join(work_dir, 'lib')
+      assert_equal File.join(work_dir, "main.rb"), entrypoint_path
+      assert_includes additional_paths, File.join(work_dir, "lib")
       # Verify files were copied
-      assert File.exist?(File.join(work_dir, 'lib', 'app.rb'))
+      assert File.exist?(File.join(work_dir, "lib", "app.rb"))
     end
   end
 
@@ -190,52 +190,52 @@ class CopyProjectFilesTest < Minitest::Test
     Dir.mktmpdir do |tmpdir|
       # Use realpath to match WorkDir behavior (resolves symlinks like /tmp -> /private/tmp on macOS)
       tmpdir = File.realpath(tmpdir)
-      work_dir = File.join(tmpdir, 'work')
-      project_dir = File.join(tmpdir, 'project')
-      config_dir = File.join(project_dir, 'config')
+      work_dir = File.join(tmpdir, "work")
+      project_dir = File.join(tmpdir, "project")
+      config_dir = File.join(project_dir, "config")
       FileUtils.mkdir_p([work_dir, config_dir])
 
       # Create files in project_dir (individual file, not directory)
-      File.write(File.join(project_dir, 'main.rb'), "require_relative 'config/settings'")
-      File.write(File.join(config_dir, 'settings.rb'), 'SETTINGS = {}')
+      File.write(File.join(project_dir, "main.rb"), "require_relative 'config/settings'")
+      File.write(File.join(config_dir, "settings.rb"), "SETTINGS = {}")
 
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
-      mock_args(project_dir: project_dir, entrypoint: 'main.rb', files: ['config/settings.rb'])
+      mock_args(project_dir: project_dir, entrypoint: "main.rb", files: ["config/settings.rb"])
 
       entrypoint_path = Kompo::CopyProjectFiles.entrypoint_path
       additional_paths = Kompo::CopyProjectFiles.additional_paths
 
-      assert_equal File.join(work_dir, 'main.rb'), entrypoint_path
-      assert_includes additional_paths, File.join(work_dir, 'config/settings.rb')
+      assert_equal File.join(work_dir, "main.rb"), entrypoint_path
+      assert_includes additional_paths, File.join(work_dir, "config/settings.rb")
       # Verify individual file was copied with parent dir created
-      assert File.exist?(File.join(work_dir, 'config', 'settings.rb'))
+      assert File.exist?(File.join(work_dir, "config", "settings.rb"))
     end
   end
 
   def test_copy_project_files_with_dot_copies_directory_contents
     Dir.mktmpdir do |tmpdir|
       tmpdir = File.realpath(tmpdir)
-      work_dir = File.join(tmpdir, 'work')
-      project_dir = File.join(tmpdir, 'project')
-      lib_dir = File.join(project_dir, 'lib')
+      work_dir = File.join(tmpdir, "work")
+      project_dir = File.join(tmpdir, "project")
+      lib_dir = File.join(project_dir, "lib")
       FileUtils.mkdir_p([work_dir, lib_dir])
 
       # Create files in project_dir
-      File.write(File.join(project_dir, 'main.rb'), "puts 'hello'")
-      File.write(File.join(project_dir, 'app.gemspec'), "Gem::Specification.new { |s| s.name = 'app' }")
-      File.write(File.join(lib_dir, 'app.rb'), 'class App; end')
+      File.write(File.join(project_dir, "main.rb"), "puts 'hello'")
+      File.write(File.join(project_dir, "app.gemspec"), "Gem::Specification.new { |s| s.name = 'app' }")
+      File.write(File.join(lib_dir, "app.rb"), "class App; end")
 
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
-      mock_args(project_dir: project_dir, entrypoint: 'main.rb', files: ['.'])
+      mock_args(project_dir: project_dir, entrypoint: "main.rb", files: ["."])
 
       Kompo::CopyProjectFiles.entrypoint_path
 
       # Verify all files were copied directly to work_dir (not into work_dir/project/)
-      assert File.exist?(File.join(work_dir, 'main.rb'))
-      assert File.exist?(File.join(work_dir, 'app.gemspec'))
-      assert File.exist?(File.join(work_dir, 'lib', 'app.rb'))
+      assert File.exist?(File.join(work_dir, "main.rb"))
+      assert File.exist?(File.join(work_dir, "app.gemspec"))
+      assert File.exist?(File.join(work_dir, "lib", "app.rb"))
       # Ensure no nested project directory was created
-      refute File.exist?(File.join(work_dir, 'project'))
+      refute File.exist?(File.join(work_dir, "project"))
     end
   end
 end

--- a/test/tasks/make_c_test.rb
+++ b/test/tasks/make_c_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../test_helper'
+require_relative "../test_helper"
 
 class MakeMainCTest < Minitest::Test
   include Taski::TestHelper::Minitest
@@ -8,10 +8,10 @@ class MakeMainCTest < Minitest::Test
 
   def test_make_main_c_generates_file
     Dir.mktmpdir do |tmpdir|
-      work_dir = File.join(tmpdir, 'work')
+      work_dir = File.join(tmpdir, "work")
       FileUtils.mkdir_p(work_dir)
-      main_c_path = File.join(work_dir, 'main.c')
-      entrypoint = File.join(work_dir, 'main.rb')
+      main_c_path = File.join(work_dir, "main.c")
+      entrypoint = File.join(work_dir, "main.rb")
 
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
       mock_task(Kompo::CopyProjectFiles, entrypoint_path: entrypoint, additional_paths: [])
@@ -19,22 +19,22 @@ class MakeMainCTest < Minitest::Test
       mock_task(Kompo::CopyGemfile, gemfile_exists: false)
       mock_task(Kompo::FindNativeExtensions, extensions: [])
       mock_task(Kompo::InstallRuby,
-                ruby_version: '3.4.1',
-                ruby_build_path: '/path/to/build',
-                ruby_path: '/path/to/ruby',
-                ruby_install_dir: '/path/to/install',
-                original_ruby_install_dir: '/path/to/install',
-                ruby_major_minor: '3.4')
+        ruby_version: "3.4.1",
+        ruby_build_path: "/path/to/build",
+        ruby_path: "/path/to/ruby",
+        ruby_install_dir: "/path/to/install",
+        original_ruby_install_dir: "/path/to/install",
+        ruby_major_minor: "3.4")
       mock_task(Kompo::BundleInstall,
-                bundle_ruby_dir: nil,
-                bundler_config_path: nil)
+        bundle_ruby_dir: nil,
+        bundler_config_path: nil)
 
       path = Kompo::MakeMainC.path
 
       assert_equal main_c_path, path
-      assert File.exist?(main_c_path), 'main.c should be generated'
+      assert File.exist?(main_c_path), "main.c should be generated"
       content = File.read(main_c_path)
-      assert_includes content, 'ruby_init'
+      assert_includes content, "ruby_init"
     end
   end
 end
@@ -50,52 +50,52 @@ class MakeFsCTest < Minitest::Test
 
       path = Kompo::MakeFsC.path
 
-      assert_equal File.join(work_dir, 'fs.c'), path
-      assert File.exist?(path), 'fs.c should be generated'
+      assert_equal File.join(work_dir, "fs.c"), path
+      assert File.exist?(path), "fs.c should be generated"
       content = File.read(path)
-      assert_includes content, 'const char FILES[]'
-      assert_includes content, 'const char PATHS[]'
+      assert_includes content, "const char FILES[]"
+      assert_includes content, "const char PATHS[]"
     end
   end
 
   def test_make_fs_c_with_additional_paths
     Dir.mktmpdir do |tmpdir|
       work_dir, entrypoint = setup_work_dir_with_entrypoint(tmpdir)
-      lib_dir = File.join(work_dir, 'lib')
+      lib_dir = File.join(work_dir, "lib")
       FileUtils.mkdir_p(lib_dir)
-      File.write(File.join(lib_dir, 'app.rb'), 'class App; end')
+      File.write(File.join(lib_dir, "app.rb"), "class App; end")
 
       mock_fs_c_dependencies(work_dir, tmpdir, entrypoint, additional_paths: [lib_dir])
 
       path = Kompo::MakeFsC.path
 
       assert File.exist?(path)
-      assert_includes File.read(path), 'const char FILES[]'
+      assert_includes File.read(path), "const char FILES[]"
     end
   end
 
   def test_make_fs_c_prunes_git_directories
     Dir.mktmpdir do |tmpdir|
       work_dir, entrypoint = setup_work_dir_with_entrypoint(tmpdir)
-      lib_dir = File.join(work_dir, 'lib')
-      git_dir = File.join(lib_dir, '.git')
+      lib_dir = File.join(work_dir, "lib")
+      git_dir = File.join(lib_dir, ".git")
       FileUtils.mkdir_p([lib_dir, git_dir])
-      File.write(File.join(lib_dir, 'app.rb'), 'class App; end')
-      File.write(File.join(git_dir, 'config'), 'git config')
+      File.write(File.join(lib_dir, "app.rb"), "class App; end")
+      File.write(File.join(git_dir, "config"), "git config")
 
       mock_fs_c_dependencies(work_dir, tmpdir, entrypoint, additional_paths: [lib_dir])
 
       path = Kompo::MakeFsC.path
 
       assert File.exist?(path)
-      refute_includes File.read(path), 'git config'
+      refute_includes File.read(path), "git config"
     end
   end
 
   def test_make_fs_c_handles_nonexistent_path
     Dir.mktmpdir do |tmpdir|
       work_dir, entrypoint = setup_work_dir_with_entrypoint(tmpdir)
-      mock_fs_c_dependencies(work_dir, tmpdir, entrypoint, additional_paths: ['/nonexistent/path'])
+      mock_fs_c_dependencies(work_dir, tmpdir, entrypoint, additional_paths: ["/nonexistent/path"])
 
       path = Kompo::MakeFsC.path
 
@@ -106,9 +106,9 @@ class MakeFsCTest < Minitest::Test
   def test_make_fs_c_skips_binary_extensions
     Dir.mktmpdir do |tmpdir|
       work_dir, entrypoint = setup_work_dir_with_entrypoint(tmpdir)
-      File.write(File.join(work_dir, 'test.so'), 'binary')
-      File.write(File.join(work_dir, 'test.o'), 'object')
-      File.write(File.join(work_dir, 'image.png'), 'image')
+      File.write(File.join(work_dir, "test.so"), "binary")
+      File.write(File.join(work_dir, "test.o"), "object")
+      File.write(File.join(work_dir, "image.png"), "image")
 
       mock_fs_c_dependencies(work_dir, tmpdir, entrypoint)
 
@@ -121,17 +121,17 @@ class MakeFsCTest < Minitest::Test
   def test_make_fs_c_with_gemfile
     Dir.mktmpdir do |tmpdir|
       work_dir, entrypoint = setup_work_dir_with_entrypoint(tmpdir, content: "require 'bundler/setup'")
-      bundle_dir = File.join(work_dir, 'bundle', 'ruby', '3.4.0')
-      bundle_config_dir = File.join(work_dir, '.bundle')
+      bundle_dir = File.join(work_dir, "bundle", "ruby", "3.4.0")
+      bundle_config_dir = File.join(work_dir, ".bundle")
       FileUtils.mkdir_p([bundle_dir, bundle_config_dir])
-      File.write(File.join(work_dir, 'Gemfile'), "source 'https://rubygems.org'")
-      File.write(File.join(work_dir, 'Gemfile.lock'), "GEM\n  specs:\n")
-      File.write(File.join(bundle_config_dir, 'config'), 'BUNDLE_PATH: bundle')
+      File.write(File.join(work_dir, "Gemfile"), "source 'https://rubygems.org'")
+      File.write(File.join(work_dir, "Gemfile.lock"), "GEM\n  specs:\n")
+      File.write(File.join(bundle_config_dir, "config"), "BUNDLE_PATH: bundle")
 
       mock_fs_c_dependencies(work_dir, tmpdir, entrypoint,
-                             gemfile_exists: true,
-                             bundler_config_path: File.join(bundle_config_dir, 'config'),
-                             bundle_ruby_dir: bundle_dir)
+        gemfile_exists: true,
+        bundler_config_path: File.join(bundle_config_dir, "config"),
+        bundle_ruby_dir: bundle_dir)
 
       path = Kompo::MakeFsC.path
 
@@ -142,9 +142,9 @@ class MakeFsCTest < Minitest::Test
   def test_make_fs_c_with_kompoignore
     Dir.mktmpdir do |tmpdir|
       work_dir, entrypoint = setup_work_dir_with_entrypoint(tmpdir)
-      project_dir = File.join(tmpdir, 'project')
+      project_dir = File.join(tmpdir, "project")
       FileUtils.mkdir_p(project_dir)
-      File.write(File.join(project_dir, '.kompoignore'), "*.log\ntmp/")
+      File.write(File.join(project_dir, ".kompoignore"), "*.log\ntmp/")
 
       mock_fs_c_dependencies(work_dir, tmpdir, entrypoint)
       mock_args(project_dir: project_dir)
@@ -158,12 +158,12 @@ class MakeFsCTest < Minitest::Test
   def test_make_fs_c_ignores_files_matching_kompoignore
     Dir.mktmpdir do |tmpdir|
       work_dir, entrypoint = setup_work_dir_with_entrypoint(tmpdir)
-      project_dir = File.join(tmpdir, 'project')
-      tmp_dir = File.join(work_dir, 'tmp')
+      project_dir = File.join(tmpdir, "project")
+      tmp_dir = File.join(work_dir, "tmp")
       FileUtils.mkdir_p([project_dir, tmp_dir])
-      File.write(File.join(work_dir, 'debug.log'), 'DEBUG LOG CONTENT')
-      File.write(File.join(tmp_dir, 'cache.txt'), 'TEMP CACHE CONTENT')
-      File.write(File.join(project_dir, '.kompoignore'), "*.log\ntmp/")
+      File.write(File.join(work_dir, "debug.log"), "DEBUG LOG CONTENT")
+      File.write(File.join(tmp_dir, "cache.txt"), "TEMP CACHE CONTENT")
+      File.write(File.join(project_dir, ".kompoignore"), "*.log\ntmp/")
 
       mock_fs_c_dependencies(work_dir, tmpdir, entrypoint)
       mock_args(project_dir: project_dir)
@@ -171,11 +171,11 @@ class MakeFsCTest < Minitest::Test
       path = Kompo::MakeFsC.path
       content = File.read(path)
       paths_match = content.match(/const char PATHS\[\] = \{([^}]+)\}/)
-      assert paths_match, 'Should have PATHS array'
-      decoded_paths = paths_match[1].split(',').map(&:to_i).pack('C*')
-      refute_includes decoded_paths, 'debug.log'
-      refute_includes decoded_paths, 'cache.txt'
-      assert_includes decoded_paths, 'main.rb'
+      assert paths_match, "Should have PATHS array"
+      decoded_paths = paths_match[1].split(",").map(&:to_i).pack("C*")
+      refute_includes decoded_paths, "debug.log"
+      refute_includes decoded_paths, "cache.txt"
+      assert_includes decoded_paths, "main.rb"
     end
   end
 
@@ -185,17 +185,17 @@ class MakeFsCTest < Minitest::Test
       tmpdir = File.realpath(tmpdir)
 
       work_dir, entrypoint = setup_work_dir_with_entrypoint(tmpdir)
-      lib_dir = File.join(work_dir, 'lib')
+      lib_dir = File.join(work_dir, "lib")
       FileUtils.mkdir_p(lib_dir)
-      File.write(File.join(lib_dir, 'app.rb'), 'class App; end')
+      File.write(File.join(lib_dir, "app.rb"), "class App; end")
 
       # Create a directory outside work_dir
-      outside_dir = File.join(tmpdir, 'outside')
+      outside_dir = File.join(tmpdir, "outside")
       FileUtils.mkdir_p(outside_dir)
-      File.write(File.join(outside_dir, 'secret.rb'), 'SECRET_DATA')
+      File.write(File.join(outside_dir, "secret.rb"), "SECRET_DATA")
 
       # Create a symlink in lib_dir pointing to outside_dir
-      symlink_path = File.join(lib_dir, 'external_link')
+      symlink_path = File.join(lib_dir, "external_link")
       File.symlink(outside_dir, symlink_path)
 
       mock_fs_c_dependencies(work_dir, tmpdir, entrypoint, additional_paths: [lib_dir])
@@ -207,13 +207,13 @@ class MakeFsCTest < Minitest::Test
       content = File.read(path)
 
       # The symlink target content should NOT be included
-      refute_includes content, 'SECRET_DATA'
+      refute_includes content, "SECRET_DATA"
 
       # Regular file should still be included
       paths_match = content.match(/const char PATHS\[\] = \{([^}]+)\}/)
-      assert paths_match, 'Should have PATHS array'
-      decoded_paths = paths_match[1].split(',').map(&:to_i).pack('C*')
-      assert_includes decoded_paths, 'app.rb'
+      assert paths_match, "Should have PATHS array"
+      decoded_paths = paths_match[1].split(",").map(&:to_i).pack("C*")
+      assert_includes decoded_paths, "app.rb"
     end
   end
 
@@ -223,14 +223,14 @@ class MakeFsCTest < Minitest::Test
       tmpdir = File.realpath(tmpdir)
 
       work_dir, entrypoint = setup_work_dir_with_entrypoint(tmpdir)
-      lib_dir = File.join(work_dir, 'lib')
-      real_dir = File.join(lib_dir, 'real')
+      lib_dir = File.join(work_dir, "lib")
+      real_dir = File.join(lib_dir, "real")
       FileUtils.mkdir_p(real_dir)
-      File.write(File.join(real_dir, 'internal.rb'), 'INTERNAL_CONTENT')
+      File.write(File.join(real_dir, "internal.rb"), "INTERNAL_CONTENT")
 
       # Create a symlink within the same base directory
-      symlink_path = File.join(lib_dir, 'linked.rb')
-      File.symlink(File.join(real_dir, 'internal.rb'), symlink_path)
+      symlink_path = File.join(lib_dir, "linked.rb")
+      File.symlink(File.join(real_dir, "internal.rb"), symlink_path)
 
       mock_fs_c_dependencies(work_dir, tmpdir, entrypoint, additional_paths: [lib_dir])
 
@@ -241,9 +241,9 @@ class MakeFsCTest < Minitest::Test
 
       # Internal symlink content should be included
       paths_match = content.match(/const char PATHS\[\] = \{([^}]+)\}/)
-      assert paths_match, 'Should have PATHS array'
-      decoded_paths = paths_match[1].split(',').map(&:to_i).pack('C*')
-      assert_includes decoded_paths, 'internal.rb'
+      assert paths_match, "Should have PATHS array"
+      decoded_paths = paths_match[1].split(",").map(&:to_i).pack("C*")
+      assert_includes decoded_paths, "internal.rb"
     end
   end
 
@@ -252,12 +252,12 @@ class MakeFsCTest < Minitest::Test
       work_dir, entrypoint = setup_work_dir_with_entrypoint(tmpdir)
 
       # Create a directory with a binary file
-      lib_dir = File.join(work_dir, 'lib')
+      lib_dir = File.join(work_dir, "lib")
       FileUtils.mkdir_p(lib_dir)
 
       # Create a file with binary content (non-UTF8 bytes)
       binary_content = "\x00\x01\x02\xFF\xFE\xFD"
-      binary_file = File.join(lib_dir, 'binary.dat.rb') # Use .rb extension to not be skipped
+      binary_file = File.join(lib_dir, "binary.dat.rb") # Use .rb extension to not be skipped
       File.binwrite(binary_file, binary_content)
 
       mock_fs_c_dependencies(work_dir, tmpdir, entrypoint, additional_paths: [lib_dir])
@@ -269,31 +269,31 @@ class MakeFsCTest < Minitest::Test
 
       # The binary bytes should be embedded in FILES array
       # Binary content: \x00\x01\x02\xFF\xFE\xFD = 0, 1, 2, 255, 254, 253
-      assert_includes content, '0,1,2,255,254,253'
+      assert_includes content, "0,1,2,255,254,253"
     end
   end
 
   private
 
   def setup_work_dir_with_entrypoint(tmpdir, content: "puts 'hello'")
-    work_dir = File.join(tmpdir, 'work')
+    work_dir = File.join(tmpdir, "work")
     FileUtils.mkdir_p(work_dir)
-    entrypoint = File.join(work_dir, 'main.rb')
+    entrypoint = File.join(work_dir, "main.rb")
     File.write(entrypoint, content)
     [work_dir, entrypoint]
   end
 
   def mock_fs_c_dependencies(work_dir, tmpdir, entrypoint,
-                             additional_paths: [],
-                             gemfile_exists: false,
-                             gemspec_paths: [],
-                             bundler_config_path: nil,
-                             bundle_ruby_dir: nil)
+    additional_paths: [],
+    gemfile_exists: false,
+    gemspec_paths: [],
+    bundler_config_path: nil,
+    bundle_ruby_dir: nil)
     mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
     mock_task(Kompo::InstallRuby,
-              ruby_install_dir: '/path/to/install',
-              original_ruby_install_dir: '/path/to/install',
-              ruby_major_minor: '3.4')
+      ruby_install_dir: "/path/to/install",
+      original_ruby_install_dir: "/path/to/install",
+      ruby_major_minor: "3.4")
     mock_task(Kompo::CopyProjectFiles, entrypoint_path: entrypoint, additional_paths: additional_paths)
     mock_task(Kompo::CopyGemfile, gemfile_exists: gemfile_exists, gemspec_paths: gemspec_paths)
     mock_task(Kompo::BundleInstall, bundler_config_path: bundler_config_path, bundle_ruby_dir: bundle_ruby_dir)

--- a/test/tasks/packing_test.rb
+++ b/test/tasks/packing_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../test_helper'
+require_relative "../test_helper"
 
 class PackingTest < Minitest::Test
   include Taski::TestHelper::Minitest
@@ -22,24 +22,24 @@ class PackingTest < Minitest::Test
 
   def test_packing_for_macos_has_system_libs_constant
     assert_kind_of Array, Kompo::Packing::ForMacOS::SYSTEM_LIBS
-    assert_includes Kompo::Packing::ForMacOS::SYSTEM_LIBS, 'pthread'
-    assert_includes Kompo::Packing::ForMacOS::SYSTEM_LIBS, 'm'
-    assert_includes Kompo::Packing::ForMacOS::SYSTEM_LIBS, 'c'
+    assert_includes Kompo::Packing::ForMacOS::SYSTEM_LIBS, "pthread"
+    assert_includes Kompo::Packing::ForMacOS::SYSTEM_LIBS, "m"
+    assert_includes Kompo::Packing::ForMacOS::SYSTEM_LIBS, "c"
   end
 
   def test_packing_for_macos_has_frameworks_constant
     assert_kind_of Array, Kompo::Packing::ForMacOS::FRAMEWORKS
-    assert_includes Kompo::Packing::ForMacOS::FRAMEWORKS, 'Foundation'
-    assert_includes Kompo::Packing::ForMacOS::FRAMEWORKS, 'CoreFoundation'
-    assert_includes Kompo::Packing::ForMacOS::FRAMEWORKS, 'Security'
+    assert_includes Kompo::Packing::ForMacOS::FRAMEWORKS, "Foundation"
+    assert_includes Kompo::Packing::ForMacOS::FRAMEWORKS, "CoreFoundation"
+    assert_includes Kompo::Packing::ForMacOS::FRAMEWORKS, "Security"
   end
 
   def test_packing_for_linux_has_dyn_link_libs_constant
     assert_kind_of Array, Kompo::Packing::ForLinux::DYN_LINK_LIBS
-    assert_includes Kompo::Packing::ForLinux::DYN_LINK_LIBS, 'pthread'
-    assert_includes Kompo::Packing::ForLinux::DYN_LINK_LIBS, 'dl'
-    assert_includes Kompo::Packing::ForLinux::DYN_LINK_LIBS, 'm'
-    assert_includes Kompo::Packing::ForLinux::DYN_LINK_LIBS, 'c'
+    assert_includes Kompo::Packing::ForLinux::DYN_LINK_LIBS, "pthread"
+    assert_includes Kompo::Packing::ForLinux::DYN_LINK_LIBS, "dl"
+    assert_includes Kompo::Packing::ForLinux::DYN_LINK_LIBS, "m"
+    assert_includes Kompo::Packing::ForLinux::DYN_LINK_LIBS, "c"
   end
 
   def test_common_helpers_module_exists
@@ -53,5 +53,4 @@ class PackingTest < Minitest::Test
   def test_for_linux_includes_common_helpers
     assert Kompo::Packing::ForLinux.include?(Kompo::Packing::CommonHelpers)
   end
-
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,30 +1,30 @@
 # frozen_string_literal: true
 
 # Coverage measurement must be started before loading any code
-if ENV['COVERAGE']
-  require 'simplecov'
+if ENV["COVERAGE"]
+  require "simplecov"
   SimpleCov.start do
-    add_filter '/test/'
-    add_filter '/vendor/'
+    add_filter "/test/"
+    add_filter "/vendor/"
     enable_coverage :branch
     primary_coverage :line
     # Track all Ruby files in lib directory
-    track_files 'lib/**/*.rb'
+    track_files "lib/**/*.rb"
   end
 end
 
 # Load taski and test helper BEFORE loading kompo tasks
 # This ensures TaskExtension is prepended to Taski::Task
 # before any task classes are defined
-require 'taski'
-require 'taski/test_helper/minitest'
-require 'digest'
+require "taski"
+require "taski/test_helper/minitest"
+require "digest"
 
 # Now load kompo (tasks will have TaskExtension prepended)
-require_relative '../lib/kompo'
+require_relative "../lib/kompo"
 
 # Force load all autoloaded constants for accurate coverage measurement
-if ENV['COVERAGE']
+if ENV["COVERAGE"]
   Kompo.constants.each do |const|
     Kompo.const_get(const) if Kompo.autoload?(const)
   rescue LoadError
@@ -32,28 +32,28 @@ if ENV['COVERAGE']
   end
 end
 
-require 'minitest/autorun'
-require 'tmpdir'
-require 'fileutils'
-require 'json'
+require "minitest/autorun"
+require "tmpdir"
+require "fileutils"
+require "json"
 
 # Common mock configurations for task tests
 module TaskTestHelpers
   STANDARD_RUBY_MOCK = {
-    ruby_path: '/path/to/ruby',
-    bundler_path: '/path/to/bundler',
-    ruby_install_dir: '/path/to/install',
-    original_ruby_install_dir: '/path/to/install',
-    ruby_version: '3.4.1',
-    ruby_major_minor: '3.4',
-    ruby_build_path: '/path/to/build'
+    ruby_path: "/path/to/ruby",
+    bundler_path: "/path/to/bundler",
+    ruby_install_dir: "/path/to/install",
+    original_ruby_install_dir: "/path/to/install",
+    ruby_version: "3.4.1",
+    ruby_major_minor: "3.4",
+    ruby_build_path: "/path/to/build"
   }.freeze
 
   def mock_standard_ruby
     mock_task(Kompo::InstallRuby, **STANDARD_RUBY_MOCK)
   end
 
-  def mock_no_gemfile_setup(work_dir: '/tmp/work', original_dir: '/tmp')
+  def mock_no_gemfile_setup(work_dir: "/tmp/work", original_dir: "/tmp")
     mock_task(Kompo::CopyGemfile, gemfile_exists: false)
     mock_task(Kompo::WorkDir, path: work_dir, original_dir: original_dir)
     mock_standard_ruby


### PR DESCRIPTION
## Summary
- Add `lint` job to CI that runs `standardrb` for code style checks
- Add `test` job to CI that runs tests separately (faster feedback)
- Fix all 932 standardrb violations (mostly single quotes → double quotes)

## Changes
- `.github/workflows/ci.yml`: Added lint and test jobs
- All Ruby files: Applied standardrb auto-fix

## Test plan
- [x] `standardrb` passes with no violations
- [x] All tests pass (150 tests, 435 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added linting and automated testing to CI pipeline.
  * Enhanced gemspec file tracking and cleanup during build operations.
  * Improved cache directory management with better version handling.

* **Chores**
  * Standardized code formatting and string literal style across the codebase for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->