### PR TITLE
Set default progress mode to simple

### DIFF
--- a/lib/kompo.rb
+++ b/lib/kompo.rb
@@ -3,6 +3,10 @@
 require "taski"
 require_relative "kompo/version"
 
+# Use simple progress mode for cleaner output
+# See taski library for details: https://github.com/ahogappa/taski
+Taski.progress_mode = :simple
+
 module Kompo
   # Fixed path prefix for Ruby installation
   # Using a fixed path ensures that cached Ruby binaries work correctly,


### PR DESCRIPTION
## Summary
- Change taski's default progress mode from tree to simple for cleaner output

## Test plan
- [x] All tests pass (`bundle exec rake test`)
- [x] Lint passes (`bundle exec standardrb`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated progress output configuration to use simplified display mode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->