### PR TITLE
Add --dry-run option to show compile command without executing

### DIFF
--- a/exe/kompo
+++ b/exe/kompo
@@ -25,6 +25,7 @@ opt = OptionParser.new do |o|
   o.on("--clean[=VERSION]", 'Clean cache (current Ruby version by default, or specify VERSION, or "all")') do |v|
     args[:clean_cache] = v.nil? ? RUBY_VERSION : v
   end
+  o.on("--dry-run", "Show final compile command without executing it") { |_v| args[:dry_run] = true }
   o.on("-t", "--tree", "Show task dependency tree and exit") do
     puts Kompo::Packing.tree
     exit(0)

--- a/lib/kompo/tasks/packing.rb
+++ b/lib/kompo/tasks/packing.rb
@@ -84,6 +84,12 @@ module Kompo
 
         command = build_command(work_dir, deps, ext_paths, enc_files)
 
+        if Taski.args[:dry_run]
+          puts "Compile command (macOS):"
+          puts Shellwords.join(command)
+          return
+        end
+
         group("Compiling binary (macOS)") do
           system(*command) or raise "Failed to compile final binary"
           puts "Binary size: #{File.size(@output_path) / 1024 / 1024} MB"
@@ -164,6 +170,12 @@ module Kompo
         @output_path = CollectDependencies.output_path
 
         command = build_command(work_dir, deps, ext_paths, enc_files)
+
+        if Taski.args[:dry_run]
+          puts "Compile command (Linux):"
+          puts Shellwords.join(command)
+          return
+        end
 
         group("Compiling binary (Linux)") do
           system(*command) or raise "Failed to compile final binary"


### PR DESCRIPTION
## Summary
- Add `--dry-run` option that shows the final compile command without executing it
- Supports both macOS (clang) and Linux (gcc) build environments
- Useful for debugging build configurations and verifying compile flags

## Test plan
- [x] All existing tests pass
- [x] Lint check passes
- [ ] Manual test: Run `kompo --dry-run -o /tmp/output <files>` and verify command is displayed but not executed

🤖 Generated with [Claude Code](https://claude.com/claude-code)