### PR TITLE
Fix get_extlibs to extract LIBS from Makefiles including bundled gems

### DIFF
--- a/lib/kompo/tasks/packing.rb
+++ b/lib/kompo/tasks/packing.rb
@@ -56,8 +56,10 @@ module Kompo
         # Extract LIBS from ext/*/Makefile and .bundle/gems/*/ext/*/Makefile
         makefiles = Dir.glob(File.join(ruby_build_dir, "{ext/*,.bundle/gems/*/ext/*}", "Makefile"))
         makefiles.flat_map do |file|
-          File.read(file).scan(/^LIBS\s*=\s*(.*)/).flatten
-        end.compact.flat_map { |l| l.split(" ") }.uniq
+          # Read file, collapse line continuations, then match both "LIBS =" and "LIBS +="
+          content = File.read(file).gsub(/\\\n/, " ")
+          content.scan(/^LIBS\s*\+?=\s*(.*)/).flatten
+        end.compact.flat_map { |l| l.split }.uniq
       end
 
       def get_gem_libs(work_dir, ruby_major_minor)


### PR DESCRIPTION
## Summary
- Fix `get_extlibs` method to extract `LIBS` from Makefiles instead of `EXTLIBS` from exts.mk
- Include bundled gems (`.bundle/gems/*/ext/*/Makefile`) in addition to standard extensions

## Problem
In Ruby 4.0+, the `EXTLIBS` variable in `exts.mk` files is always empty. The actual link flags (like `-lffi` for fiddle) are in the `LIBS` variable of individual `Makefile`s.

This caused linker errors when building binaries that include bundled gems like fiddle:
```
"_ffi_call", referenced from: ...
"_ffi_type_void", referenced from: ...
ld: symbol(s) not found for architecture arm64
```

## Solution
Changed `get_extlibs` to extract `LIBS` from:
- `ext/*/Makefile` (standard extensions)
- `.bundle/gems/*/ext/*/Makefile` (bundled gems like fiddle)

## Test plan
- [x] All existing tests pass (153 runs, 0 failures)
- [ ] Manual test: build a binary that uses fiddle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Progressive Web App (PWA) support with manifest and service worker.
  * Upgraded to Rails 8.1 and Ruby 4.0.1.
  * Integrated new caching and background job systems (Solid Cache, Solid Queue, Solid Cable).
  * Added Thruster web server integration.

* **Bug Fixes**
  * Modernized error pages (400, 404, 422, 500) with improved accessibility and responsive design.
  * Enhanced Docker deployment with non-root user support.

* **Refactor**
  * Migrated from Sprockets to Propshaft asset pipeline.
  * Simplified Puma and CI/CD configuration.

* **Chores**
  * Removed legacy system test infrastructure and ActionCable test base classes.
  * Standardized code style and removed frozen string directives.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->