### PR TITLE
Use Taski.message instead of puts for dry-run output

### DIFF
--- a/lib/kompo/tasks/packing.rb
+++ b/lib/kompo/tasks/packing.rb
@@ -91,7 +91,7 @@ module Kompo
 
         if Taski.args[:dry_run]
           puts "Compile command (macOS):"
-          puts Shellwords.join(command)
+          Taski.message(Shellwords.join(command))
           return
         end
 
@@ -178,7 +178,7 @@ module Kompo
 
         if Taski.args[:dry_run]
           puts "Compile command (Linux):"
-          puts Shellwords.join(command)
+          Taski.message(Shellwords.join(command))
           return
         end
 


### PR DESCRIPTION
## Summary
- Replace `puts` with `Taski.message` for dry-run compile command output in packing.rb

🤖 Generated with [Claude Code](https://claude.com/claude-code)