### PR TITLE
Remove redundant compile command label from dry-run output

### DIFF
--- a/lib/kompo/tasks/packing.rb
+++ b/lib/kompo/tasks/packing.rb
@@ -90,7 +90,6 @@ module Kompo
         command = build_command(work_dir, deps, ext_paths, enc_files)
 
         if Taski.args[:dry_run]
-          puts "Compile command (macOS):"
           Taski.message(Shellwords.join(command))
           return
         end
@@ -177,7 +176,6 @@ module Kompo
         command = build_command(work_dir, deps, ext_paths, enc_files)
 
         if Taski.args[:dry_run]
-          puts "Compile command (Linux):"
           Taski.message(Shellwords.join(command))
           return
         end


### PR DESCRIPTION
## Summary
- Remove `puts "Compile command (macOS/Linux):"` lines since Taski.message handles output formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed redundant platform-specific headers from dry-run mode output during the build process, streamlining console output while preserving the actual command information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->