### PR TITLE
Update README to match actual implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,13 @@ Options:
         --ruby-source=PATH       Path to Ruby source tarball or directory
         --no-cache               Build Ruby from source, ignoring cache
         --no-stdlib              Exclude Ruby standard library from binary
+        --no-gemfile             Skip Gemfile processing (no bundle install)
         --local-vfs-path=PATH    Path to local kompo-vfs for development
         --clean[=VERSION]        Clean cache (current version by default, or specify VERSION, or "all")
+        --dry-run                Show final compile command without executing it
     -t, --tree                   Show task dependency tree and exit
-    -h, --help                   Show help message
+    -v, --version                Show version
+    -h, --help                   Show this help message
 
 Files:
     Additional files and directories to include in the binary
@@ -81,9 +84,12 @@ Files:
 | `--ruby-source` | Use a local Ruby source instead of downloading. Useful for custom Ruby builds. |
 | `--no-cache` | Force a fresh Ruby build, ignoring any cached version. |
 | `--no-stdlib` | Reduce binary size by excluding Ruby standard library. Only use if your app doesn't need stdlib. |
+| `--no-gemfile` | Skip Gemfile processing and bundle install. Useful when your project doesn't use Bundler. |
 | `--local-vfs-path` | Use a local kompo-vfs build instead of Homebrew installation. Useful for development. |
 | `--clean` | Remove cached Ruby builds. Use `--clean=all` to remove all versions. |
+| `--dry-run` | Show the final compile command without executing it. Useful for debugging build issues. |
 | `-t, --tree` | Display the task dependency graph and exit without building. |
+| `-v, --version` | Display the kompo version and exit. |
 
 ### Examples
 
@@ -137,14 +143,18 @@ node_modules/   # Ignore node_modules
 - Patterns are matched against paths relative to the project root
 - Comments and empty lines are ignored
 
-## examples
+## Samples
 
-* hello
-  * simple hello world script.
-* sinatra_and_sqlite
-  * simple sinatra app with sqlite3.
-* rails
-  * simple Rails 7.1 application.
+Sample applications demonstrating various use cases are available in the [samples](./samples) directory:
+
+* [hello](./samples/hello)
+  * Simple hello world script.
+* [native_gems](./samples/native_gems)
+  * Demonstrates native extension gems (nokogiri, sqlite3, and msgpack).
+* [sinatra_and_sqlite](./samples/sinatra_and_sqlite)
+  * Simple Sinatra app with SQLite3.
+* [rails](./samples/rails/sample)
+  * Simple Rails application.
 
 ## Development
 

--- a/samples/native_gems/README.md
+++ b/samples/native_gems/README.md
@@ -1,14 +1,15 @@
 # Native Gems Sample
 
-A sample application that uses native extension gems (sqlite3 and msgpack) to verify kompo can correctly bundle and run binaries with native dependencies.
+A sample application that uses native extension gems (nokogiri, sqlite3, and msgpack) to verify kompo can correctly bundle and run binaries with native dependencies.
 
 ## What it does
 
-1. Creates an in-memory SQLite database
-2. Serializes user data using MessagePack
-3. Stores serialized data in SQLite
-4. Retrieves and deserializes the data
-5. Outputs the results
+1. Parses HTML using Nokogiri
+2. Creates an in-memory SQLite database
+3. Serializes user data using MessagePack
+4. Stores serialized data in SQLite
+5. Retrieves and deserializes the data
+6. Outputs the results
 
 ## Build
 
@@ -21,6 +22,10 @@ kompo -o .
 
 ```text
 === Native Gems Test ===
+
+--- Nokogiri Test ---
+Title: Hello
+Paragraph: World
 
 --- SQLite3 Test ---
 --- MessagePack Test ---
@@ -37,5 +42,5 @@ User 2: Bob
   Permissions: read
   Active: true
 
-SUCCESS: sqlite3 and msgpack are working correctly!
+SUCCESS: nokogiri, sqlite3 and msgpack are working correctly!
 ```


### PR DESCRIPTION
## Summary
- Add missing CLI options to documentation: `--no-gemfile`, `--dry-run`, `-v/--version`
- Rename "examples" section to "Samples" with clickable links
- Add `native_gems` sample to the samples list
- Update `native_gems` README to include nokogiri in the description

## Test plan
- [x] Verify CLI options match `exe/kompo --help` output
- [x] Verify samples list matches `samples/` directory structure
- [x] Run `bundle exec rake test` - all tests pass
- [x] Run `bundle exec rake standard` - no lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)