### PR TITLE
Add working directory context to dry-run compile command

### DIFF
--- a/lib/kompo/tasks/packing.rb
+++ b/lib/kompo/tasks/packing.rb
@@ -90,7 +90,7 @@ module Kompo
         command = build_command(work_dir, deps, ext_paths, enc_files)
 
         if Taski.args[:dry_run]
-          Taski.message(Shellwords.join(command))
+          Taski.message("cd #{Shellwords.escape(work_dir)} && #{Shellwords.join(command)}")
           return
         end
 
@@ -176,7 +176,7 @@ module Kompo
         command = build_command(work_dir, deps, ext_paths, enc_files)
 
         if Taski.args[:dry_run]
-          Taski.message(Shellwords.join(command))
+          Taski.message("cd #{Shellwords.escape(work_dir)} && #{Shellwords.join(command)}")
           return
         end
 


### PR DESCRIPTION
## Summary
- Add `cd <work_dir> &&` prefix to compile command shown with dry-run option
- Allow users to copy and paste the command directly for execution
- Properly escape paths with special characters using `Shellwords.escape`

## Test plan
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)