### PR TITLE
Remove explicit InstallDeps.run call in CollectDependencies

### DIFF
--- a/lib/kompo/tasks/collect_dependencies.rb
+++ b/lib/kompo/tasks/collect_dependencies.rb
@@ -47,8 +47,6 @@ module Kompo
     private
 
     def collect_dependencies
-      # Install dependencies based on platform (Homebrew on macOS, pkg-config check on Linux)
-      InstallDeps.run
       deps_lib_paths = InstallDeps.lib_paths
 
       ruby_install_dir = InstallRuby.ruby_install_dir


### PR DESCRIPTION
## Summary
- Remove explicit `InstallDeps.run` call in `CollectDependencies`
- Follow Taski framework pattern where accessing exported values (`lib_paths`) automatically triggers task execution
- Consistent with how `Packing` accesses `CollectDependencies` values

## Test plan
- [x] All tests pass (153 runs, 443 assertions, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)