### PR TITLE
Add static linking support for external libraries on macOS

### DIFF
--- a/exe/kompo
+++ b/exe/kompo
@@ -26,6 +26,9 @@ opt = OptionParser.new do |o|
     args[:clean_cache] = v.nil? ? RUBY_VERSION : v
   end
   o.on("--dry-run", "Show final compile command without executing it") { |_v| args[:dry_run] = true }
+  o.on("--dynamic-libs=LIBS", "Comma-separated list of libraries to link dynamically (e.g., ssl,crypto,gmp)") do |v|
+    args[:dynamic_libs] = v.split(",").map(&:strip)
+  end
   o.on("-t", "--tree", "Show task dependency tree and exit") do
     puts Kompo::Packing.tree
     exit(0)

--- a/lib/kompo/tasks/collect_dependencies.rb
+++ b/lib/kompo/tasks/collect_dependencies.rb
@@ -11,7 +11,7 @@ module Kompo
     Dependencies = Struct.new(
       :ruby_install_dir, :ruby_version, :ruby_major_minor,
       :ruby_build_path, :ruby_lib, :kompo_lib,
-      :main_c, :fs_c, :exts_dir, :deps_lib_paths,
+      :main_c, :fs_c, :exts_dir, :deps_lib_paths, :static_libs,
       keyword_init: true
     )
 
@@ -48,6 +48,7 @@ module Kompo
 
     def collect_dependencies
       deps_lib_paths = InstallDeps.lib_paths
+      static_libs = InstallDeps.static_libs
 
       ruby_install_dir = InstallRuby.ruby_install_dir
       ruby_version = InstallRuby.ruby_version
@@ -72,7 +73,8 @@ module Kompo
         main_c: main_c,
         fs_c: fs_c,
         exts_dir: exts_dir,
-        deps_lib_paths: deps_lib_paths
+        deps_lib_paths: deps_lib_paths,
+        static_libs: static_libs
       )
     end
 

--- a/test/tasks/collect_dependencies_test.rb
+++ b/test/tasks/collect_dependencies_test.rb
@@ -24,7 +24,7 @@ class CollectDependenciesTest < Minitest::Test
       mock_task(Kompo::MakeMainC, path: File.join(work_dir, "main.c"))
       mock_task(Kompo::MakeFsC, path: File.join(work_dir, "fs.c"))
       mock_task(Kompo::BuildNativeGem, exts_dir: nil, exts: [])
-      mock_task(Kompo::InstallDeps, lib_paths: "")
+      mock_task(Kompo::InstallDeps, lib_paths: "", static_libs: [])
       mock_args(project_dir: project_dir, output_dir: output_dir)
 
       output_path = Kompo::CollectDependencies.output_path
@@ -51,7 +51,7 @@ class CollectDependenciesTest < Minitest::Test
       mock_task(Kompo::MakeMainC, path: File.join(work_dir, "main.c"))
       mock_task(Kompo::MakeFsC, path: File.join(work_dir, "fs.c"))
       mock_task(Kompo::BuildNativeGem, exts_dir: nil, exts: [])
-      mock_task(Kompo::InstallDeps, lib_paths: "")
+      mock_task(Kompo::InstallDeps, lib_paths: "", static_libs: [])
       mock_args(project_dir: project_dir, output_dir: output_file)
 
       output_path = Kompo::CollectDependencies.output_path
@@ -78,7 +78,7 @@ class CollectDependenciesTest < Minitest::Test
       mock_task(Kompo::MakeMainC, path: "/test/main.c")
       mock_task(Kompo::MakeFsC, path: "/test/fs.c")
       mock_task(Kompo::BuildNativeGem, exts_dir: "/test/exts", exts: ["ext1"])
-      mock_task(Kompo::InstallDeps, lib_paths: "")
+      mock_task(Kompo::InstallDeps, lib_paths: "", static_libs: [])
       mock_args(project_dir: project_dir, output_dir: output_dir)
 
       # Access deps through exported value


### PR DESCRIPTION
## Summary

- Add static library path collection for Homebrew dependencies
- Replace `-l<name>` flags with static library full paths in macOS linker command
- Add `--dynamic-libs` option to allow specific libraries to remain dynamically linked
- Dynamically build static library map from collected paths instead of hardcoding

## Changes

### Before
Binary had dynamic dependencies on external libraries:
- libgmp.10.dylib
- liblzma.5.dylib
- libz.1.dylib
- libyaml-0.2.dylib
- libssl.3.dylib / libcrypto.3.dylib
- libffi.8.dylib

### After
All external libraries are statically linked. Only macOS system libraries remain:
- /usr/lib/libobjc.A.dylib
- /usr/lib/libiconv.2.dylib
- /usr/lib/libSystem.B.dylib
- Foundation/CoreFoundation/Security frameworks

### New Option
`--dynamic-libs=LIBS` - Comma-separated list of libraries to link dynamically

Example:
```sh
kompo . -o output --dynamic-libs=ssl,crypto
```

## Test plan

- [x] All existing tests pass
- [x] Build Rails sample and verify with `otool -L` that external libraries are statically linked
- [x] Verify `--dynamic-libs` option works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--dynamic-libs` CLI option to specify which libraries should link dynamically (e.g., `--dynamic-libs=ssl,crypto`).
  * Enhanced macOS builds with improved static library path collection and dynamic/static library resolution.
  * Added support for XZ (lzma) as a new dependency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->