### PR TITLE
Add static linking support and --dynamic-libs option for Linux

### DIFF
--- a/lib/kompo/tasks/install_deps.rb
+++ b/lib/kompo/tasks/install_deps.rb
@@ -419,17 +419,19 @@ module Kompo
 
         check_dependencies
         @lib_paths = collect_lib_paths
-        @static_libs = [] # Linux uses -Wl,-Bstatic instead of explicit paths
+        @static_libs = collect_static_libs
 
         puts "All required development libraries are installed."
       end
 
       REQUIRED_LIBS = {
-        "openssl" => {pkg_config: "openssl", apt: "libssl-dev", yum: "openssl-devel"},
-        "readline" => {pkg_config: "readline", apt: "libreadline-dev", yum: "readline-devel"},
-        "zlib" => {pkg_config: "zlib", apt: "zlib1g-dev", yum: "zlib-devel"},
-        "libyaml" => {pkg_config: "yaml-0.1", apt: "libyaml-dev", yum: "libyaml-devel"},
-        "libffi" => {pkg_config: "libffi", apt: "libffi-dev", yum: "libffi-devel"}
+        "openssl" => {pkg_config: "openssl", apt: "libssl-dev", yum: "openssl-devel", static_libs: %w[libssl.a libcrypto.a]},
+        "readline" => {pkg_config: "readline", apt: "libreadline-dev", yum: "readline-devel", static_libs: %w[libreadline.a libhistory.a]},
+        "zlib" => {pkg_config: "zlib", apt: "zlib1g-dev", yum: "zlib-devel", static_libs: %w[libz.a]},
+        "libyaml" => {pkg_config: "yaml-0.1", apt: "libyaml-dev", yum: "libyaml-devel", static_libs: %w[libyaml.a]},
+        "libffi" => {pkg_config: "libffi", apt: "libffi-dev", yum: "libffi-devel", static_libs: %w[libffi.a]},
+        "gmp" => {pkg_config: "gmp", apt: "libgmp-dev", yum: "gmp-devel", static_libs: %w[libgmp.a], optional: true},
+        "liblzma" => {pkg_config: "liblzma", apt: "liblzma-dev", yum: "xz-devel", static_libs: %w[liblzma.a], optional: true}
       }.freeze
 
       private
@@ -440,18 +442,38 @@ module Kompo
 
       def check_dependencies
         missing = REQUIRED_LIBS.reject do |_, info|
-          system("pkg-config --exists #{info[:pkg_config]} 2>/dev/null")
+          info[:optional] || system("pkg-config --exists #{info[:pkg_config]} 2>/dev/null")
         end
 
         raise build_error_message(missing) unless missing.empty?
       end
 
       def collect_lib_paths
-        pkg_names = REQUIRED_LIBS.values.map { |info| info[:pkg_config] }
+        pkg_names = REQUIRED_LIBS.values
+          .select { |info| system("pkg-config --exists #{info[:pkg_config]} 2>/dev/null") }
+          .map { |info| info[:pkg_config] }
         paths = pkg_names.flat_map do |pkg|
           `pkg-config --libs-only-L #{pkg} 2>/dev/null`.chomp.split
         end
         paths.uniq.join(" ")
+      end
+
+      def collect_static_libs
+        static_libs = []
+
+        REQUIRED_LIBS.each do |_, info|
+          next unless system("pkg-config --exists #{info[:pkg_config]} 2>/dev/null")
+
+          libdir = `pkg-config --variable=libdir #{info[:pkg_config]} 2>/dev/null`.chomp
+          next if libdir.empty?
+
+          info[:static_libs]&.each do |lib_name|
+            lib_path = File.join(libdir, lib_name)
+            static_libs << lib_path if File.exist?(lib_path)
+          end
+        end
+
+        static_libs
       end
 
       def build_error_message(missing)


### PR DESCRIPTION
## Summary

Extend the static linking support and `--dynamic-libs` option to Linux platform.

## Changes

### `install_deps.rb` (ForLinux)
- Add `collect_static_libs` method to collect static library paths using pkg-config
- Add gmp and liblzma to `REQUIRED_LIBS` (as optional dependencies)
- Each library now includes `static_libs` array specifying the `.a` filenames

### `packing.rb` (ForLinux)
- Support `--dynamic-libs` option
- User-specified dynamic libs are moved to `-Wl,-Bdynamic` section
- System libs (pthread, dl, m, c) always remain dynamically linked

## Example

```sh
# All external libraries statically linked (default)
kompo . -o output

# Keep ssl and crypto dynamically linked
kompo . -o output --dynamic-libs=ssl,crypto
```

## Test plan

- [x] All existing tests pass
- [ ] Build on Linux and verify with `ldd` that specified libraries are dynamically linked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user-configurable dynamic library support for Linux builds.
  * Linux optional dependency handling now skips missing optional libs.

* **Chores**
  * Improved static library discovery and validation on Linux.
  * Refined dependency resolution to prefer available system libraries.

* **Tests**
  * Added tests verifying static_libs exposure and optional flags; added macOS Xz install section.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->