### PR TITLE
fix: capture subprocess output to prevent progress display interference

### DIFF
--- a/test/command_runner_test.rb
+++ b/test/command_runner_test.rb
@@ -200,6 +200,23 @@ class CommandRunnerRunTest < Minitest::Test
 
     refute result
   end
+
+  def test_run_returns_false_for_nonexistent_command
+    result = Kompo::CommandRunner.run("nonexistent_command_xyz123")
+
+    refute result
+  end
+
+  def test_run_returns_false_for_nonexistent_command_with_error_message
+    # When command doesn't exist (Errno::ENOENT), should return false
+    # even if error_message is set (error_message only applies to command failures)
+    result = Kompo::CommandRunner.run(
+      "nonexistent_command_xyz123",
+      error_message: "This should not be raised"
+    )
+
+    refute result
+  end
 end
 
 class CommandRunnerWhichTest < Minitest::Test


### PR DESCRIPTION
## Summary
- Change `CommandRunner.run()` to use `Open3.popen2e` instead of `system()` to capture stdout/stderr
- Prevents subprocess output from mixing with Taski's progress display

## Problem
When running `kompo`, subprocess output (from `ruby-build`, `cargo`, etc.) was appearing inline with the progress spinner:

```
⠸ [35/41] BuildNativeGemwarning: profiles for the non root package will be ignored...
⠼ [35/41] BuildNativeGem    Finished `release` profile [optimized] target(s) in 0.20s
⠏ [35/41] BuildNativeGemruby-build: using openssl@3 from homebrew
```

## Solution
Capture subprocess output instead of letting it flow directly to the terminal. On failure, the captured output is printed via `warn` for debugging purposes.

## Test plan
- [x] All existing tests pass
- [x] `rake standard` passes
- [ ] Manual test: run `kompo . --compress --no-cache` and verify progress display is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized command execution to capture combined output non-intrusively, preserving progress display and improving diagnostics and error reporting on failures.

* **Tests**
  * Added tests to verify behavior for nonexistent commands, ensuring the run path returns false even when an error message is provided.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->