### PR TITLE
feat: add --compress option for zlib compression of embedded files

### DIFF
--- a/exe/kompo
+++ b/exe/kompo
@@ -30,6 +30,9 @@ opt = OptionParser.new do |o|
   o.on("--dynamic-libs=LIBS", "Comma-separated list of libraries to link dynamically (e.g., ssl,crypto,gmp)") do |v|
     args[:dynamic_libs] = v.split(",").map(&:strip)
   end
+  o.on("--compress", "Enable zlib compression for embedded files (reduces binary size)") do |_v|
+    args[:compress] = true
+  end
   o.on("--cache-dir=PATH", "Cache directory (default: ~/.kompo/cache)") do |v|
     args[:cache_dir] = File.expand_path(v)
   end

--- a/lib/fs.c.erb
+++ b/lib/fs.c.erb
@@ -1,6 +1,37 @@
+// Compression flag (0 = disabled, 1 = enabled)
+const int COMPRESSION_ENABLED = <%= @compress ? 1 : 0 %>;
+
+<% if @compress %>
+// Compressed file data (.rodata section - stored on disk)
+const char COMPRESSED_FILES[] = {<%= @compressed_data.join(',') %>};
+const int COMPRESSED_FILES_SIZE = <%= @compressed_data.size %>;
+const unsigned long long COMPRESSED_SIZES[] = {0};
+
+// Decompression buffer (.bss section - zero bytes on disk, allocated at runtime)
+char FILES_BUFFER[<%= @original_total_size %>];
+const int FILES_BUFFER_SIZE = <%= @original_total_size %>;
+const unsigned long long ORIGINAL_SIZES[] = {<%= @file_sizes.join(',') %>};
+
+// Dummy symbols for backward compatibility (not used when compression enabled)
+const char FILES[] = {0};
+const int FILES_SIZE = 0;
+const unsigned long long FILES_SIZES[] = {0};
+<% else %>
+// Uncompressed file data (original implementation)
 const char FILES[] = {<%= @file_bytes.join(',') %>};
 const int FILES_SIZE = <%= @file_bytes.size %>;
 const unsigned long long FILES_SIZES[] = {<%= @file_sizes.join(',') %>};
+
+// Dummy symbols for compression support (not used when compression disabled)
+const char COMPRESSED_FILES[] = {0};
+const int COMPRESSED_FILES_SIZE = 0;
+const unsigned long long COMPRESSED_SIZES[] = {0};
+char FILES_BUFFER[1];
+const int FILES_BUFFER_SIZE = 0;
+const unsigned long long ORIGINAL_SIZES[] = {0};
+<% end %>
+
+// Path data (always uncompressed)
 const char PATHS[] = {<%= @paths.join(',') %>};
 const int PATHS_SIZE = <%= @paths.size %>;
 const char WD[] = {<%= context.work_dir.bytes.join(',') %>,0};


### PR DESCRIPTION
## Summary
- Add `--compress` CLI option to enable zlib compression for embedded files
- Reduces binary size by compressing file data at build time
- Files are decompressed at runtime when accessed

## Changes
- `exe/kompo`: Add `--compress` option
- `lib/fs.c.erb`: Support both compressed and uncompressed modes
- `lib/kompo/tasks/make_fs_c.rb`: Add compression logic using `Zlib.deflate`
- `test/tasks/make_c_test.rb`: Add tests for compression functionality

## Usage
```bash
kompo . --compress
```

## Test plan
- [x] All existing tests pass
- [x] `rake standard` passes
- [x] New tests for compression added and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--compress` command-line option to reduce binary size by compressing embedded files
  * Maintains backward compatibility when compression is disabled
  * Supports runtime decompression of compressed files

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->