### PR TITLE
Remove unnecessary Skip task classes

### DIFF
--- a/lib/kompo/tasks/build_native_gem.rb
+++ b/lib/kompo/tasks/build_native_gem.rb
@@ -16,8 +16,7 @@ module Kompo
     def run
       extensions = FindNativeExtensions.extensions
       if extensions.empty?
-        @exts = Skip.exts
-        @exts_dir = Skip.exts_dir
+        puts "No native extensions to build"
         return
       end
 
@@ -274,20 +273,6 @@ module Kompo
         copy_targets = objs.split.map { |o| File.join(dir_name, o) }
         dest_dir = FileUtils.mkdir_p(dest_ext_dir).first
         FileUtils.cp(copy_targets, dest_dir)
-      end
-    end
-
-    # Skip when no native extensions
-    class Skip < Taski::Task
-      exports :exts, :exts_dir
-
-      def run
-        puts "No native extensions to build"
-        @exts = []
-        @exts_dir = nil
-      end
-
-      def clean
       end
     end
 

--- a/lib/kompo/tasks/bundle_install.rb
+++ b/lib/kompo/tasks/bundle_install.rb
@@ -14,8 +14,7 @@ module Kompo
     def run
       # Skip if no Gemfile
       unless CopyGemfile.gemfile_exists
-        @bundle_ruby_dir = Skip.bundle_ruby_dir
-        @bundler_config_path = Skip.bundler_config_path
+        puts "No Gemfile, skipping bundle install"
         return
       end
 
@@ -168,20 +167,6 @@ module Kompo
           bundle_cache.save(work_dir)
           puts "Saved to: #{bundle_cache.cache_dir}"
         end
-      end
-    end
-
-    # Skip bundle install when no Gemfile
-    class Skip < Taski::Task
-      exports :bundle_ruby_dir, :bundler_config_path
-
-      def run
-        puts "No Gemfile, skipping bundle install"
-        @bundle_ruby_dir = nil
-        @bundler_config_path = nil
-      end
-
-      def clean
       end
     end
 

--- a/test/tasks/native_extensions_test.rb
+++ b/test/tasks/native_extensions_test.rb
@@ -201,7 +201,7 @@ class BuildNativeGemTest < Minitest::Test
     exts = Kompo::BuildNativeGem.exts
     exts_dir = Kompo::BuildNativeGem.exts_dir
 
-    assert_equal [], exts
+    assert_nil exts
     assert_nil exts_dir
     assert_task_accessed(Kompo::FindNativeExtensions, :extensions)
   end


### PR DESCRIPTION
## Summary
- Remove `BundleInstall::Skip` and `BuildNativeGem::Skip` task classes that were only used to return nil/empty values
- Taski returns nil for unset exports by default, so dedicated Skip classes are redundant
- Downstream consumers already handle nil safely (`|| []`, nil guards, `.compact`)

## Test plan
- [x] All 301 tests pass
- [x] standardrb lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified build and bundle task execution with clearer console messaging during edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->