### PR TITLE
Add TmpDir helper for declarative test file setup

### DIFF
--- a/test/brew_package_test.rb
+++ b/test/brew_package_test.rb
@@ -59,9 +59,8 @@ class BrewPackageTest < Minitest::Test
 
   def test_static_libs_returns_existing_files
     with_tmpdir do |tmpdir|
+      tmpdir << "lib/libtest.a"
       lib_dir = File.join(tmpdir, "lib")
-      FileUtils.mkdir_p(lib_dir)
-      FileUtils.touch(File.join(lib_dir, "libtest.a"))
 
       @mock.stub(["/brew", "--prefix", "testpkg"], output: tmpdir, success: true)
 

--- a/test/bundle_cache_test.rb
+++ b/test/bundle_cache_test.rb
@@ -7,7 +7,7 @@ class BundleCacheTest < Minitest::Test
   def test_compute_gemfile_lock_hash_returns_hash
     with_tmpdir do |tmpdir|
       gemfile_lock_content = "GEM\n  specs:\n"
-      File.write(File.join(tmpdir, "Gemfile.lock"), gemfile_lock_content)
+      tmpdir << ["Gemfile.lock", gemfile_lock_content]
 
       hash = Kompo::BundleCache.compute_gemfile_lock_hash(tmpdir)
 
@@ -27,7 +27,7 @@ class BundleCacheTest < Minitest::Test
   def test_from_work_dir_creates_cache_instance
     with_tmpdir do |tmpdir|
       gemfile_lock_content = "GEM\n  specs:\n"
-      File.write(File.join(tmpdir, "Gemfile.lock"), gemfile_lock_content)
+      tmpdir << ["Gemfile.lock", gemfile_lock_content]
 
       cache = Kompo::BundleCache.from_work_dir(
         cache_dir: "/tmp/cache",
@@ -110,9 +110,9 @@ class BundleCacheTest < Minitest::Test
   def test_save_creates_cache_structure
     with_tmpdir do |tmpdir|
       work_dir = File.join(tmpdir, "work")
-      FileUtils.mkdir_p(File.join(work_dir, "bundle", "ruby", "3.4.0"))
-      FileUtils.mkdir_p(File.join(work_dir, ".bundle"))
-      File.write(File.join(work_dir, ".bundle", "config"), "BUNDLE_PATH: bundle")
+      tmpdir << "work/bundle/ruby/3.4.0/" \
+             << "work/.bundle/" \
+             << ["work/.bundle/config", "BUNDLE_PATH: bundle"]
 
       cache = Kompo::BundleCache.new(
         cache_dir: File.join(tmpdir, "cache"),
@@ -132,8 +132,7 @@ class BundleCacheTest < Minitest::Test
   def test_save_creates_metadata_with_correct_content
     with_tmpdir do |tmpdir|
       work_dir = File.join(tmpdir, "work")
-      FileUtils.mkdir_p(File.join(work_dir, "bundle"))
-      FileUtils.mkdir_p(File.join(work_dir, ".bundle"))
+      tmpdir << "work/bundle/" << "work/.bundle/"
 
       cache = Kompo::BundleCache.new(
         cache_dir: File.join(tmpdir, "cache"),
@@ -153,9 +152,8 @@ class BundleCacheTest < Minitest::Test
   def test_save_overwrites_existing_cache
     with_tmpdir do |tmpdir|
       work_dir = File.join(tmpdir, "work")
-      FileUtils.mkdir_p(File.join(work_dir, "bundle"))
-      FileUtils.mkdir_p(File.join(work_dir, ".bundle"))
-      File.write(File.join(work_dir, ".bundle", "config"), "NEW_CONFIG")
+      tmpdir << "work/bundle/" \
+             << ["work/.bundle/config", "NEW_CONFIG"]
 
       cache = Kompo::BundleCache.new(
         cache_dir: File.join(tmpdir, "cache"),
@@ -192,7 +190,7 @@ class BundleCacheTest < Minitest::Test
 
       # Restore to work directory
       work_dir = File.join(tmpdir, "work")
-      FileUtils.mkdir_p(work_dir)
+      tmpdir << "work/"
 
       cache.restore(work_dir)
 
@@ -217,9 +215,8 @@ class BundleCacheTest < Minitest::Test
 
       # Create work directory with existing files
       work_dir = File.join(tmpdir, "work")
-      FileUtils.mkdir_p(File.join(work_dir, "bundle", "old"))
-      FileUtils.mkdir_p(File.join(work_dir, ".bundle"))
-      File.write(File.join(work_dir, ".bundle", "config"), "OLD_CONFIG")
+      tmpdir << "work/bundle/old/" \
+             << ["work/.bundle/config", "OLD_CONFIG"]
 
       cache.restore(work_dir)
 

--- a/test/native_extension_cache_test.rb
+++ b/test/native_extension_cache_test.rb
@@ -7,7 +7,7 @@ class NativeExtensionCacheTest < Minitest::Test
   def test_compute_gemfile_lock_hash_returns_hash
     with_tmpdir do |tmpdir|
       gemfile_lock_content = "GEM\n  specs:\n"
-      File.write(File.join(tmpdir, "Gemfile.lock"), gemfile_lock_content)
+      tmpdir << ["Gemfile.lock", gemfile_lock_content]
 
       hash = Kompo::NativeExtensionCache.compute_gemfile_lock_hash(tmpdir)
 
@@ -27,7 +27,7 @@ class NativeExtensionCacheTest < Minitest::Test
   def test_from_work_dir_creates_cache_instance
     with_tmpdir do |tmpdir|
       gemfile_lock_content = "GEM\n  specs:\n"
-      File.write(File.join(tmpdir, "Gemfile.lock"), gemfile_lock_content)
+      tmpdir << ["Gemfile.lock", gemfile_lock_content]
 
       cache = Kompo::NativeExtensionCache.from_work_dir(
         cache_dir: "/tmp/cache",
@@ -109,8 +109,7 @@ class NativeExtensionCacheTest < Minitest::Test
   def test_save_creates_cache_structure
     with_tmpdir do |tmpdir|
       work_dir = File.join(tmpdir, "work")
-      FileUtils.mkdir_p(File.join(work_dir, "ext", "nokogiri"))
-      File.write(File.join(work_dir, "ext", "nokogiri", "nokogiri.o"), "object file content")
+      tmpdir << ["work/ext/nokogiri/nokogiri.o", "object file content"]
 
       cache = Kompo::NativeExtensionCache.new(
         cache_dir: File.join(tmpdir, "cache"),
@@ -131,7 +130,7 @@ class NativeExtensionCacheTest < Minitest::Test
   def test_save_creates_metadata_with_correct_content
     with_tmpdir do |tmpdir|
       work_dir = File.join(tmpdir, "work")
-      FileUtils.mkdir_p(File.join(work_dir, "ext"))
+      tmpdir << "work/ext/"
 
       cache = Kompo::NativeExtensionCache.new(
         cache_dir: File.join(tmpdir, "cache"),
@@ -153,7 +152,7 @@ class NativeExtensionCacheTest < Minitest::Test
   def test_save_does_nothing_when_no_ext_dir
     with_tmpdir do |tmpdir|
       work_dir = File.join(tmpdir, "work")
-      FileUtils.mkdir_p(work_dir)
+      tmpdir << "work/"
       # No ext/ directory
 
       cache = Kompo::NativeExtensionCache.new(
@@ -171,8 +170,7 @@ class NativeExtensionCacheTest < Minitest::Test
   def test_save_overwrites_existing_cache
     with_tmpdir do |tmpdir|
       work_dir = File.join(tmpdir, "work")
-      FileUtils.mkdir_p(File.join(work_dir, "ext", "new_gem"))
-      File.write(File.join(work_dir, "ext", "new_gem", "new.o"), "new content")
+      tmpdir << ["work/ext/new_gem/new.o", "new content"]
 
       cache = Kompo::NativeExtensionCache.new(
         cache_dir: File.join(tmpdir, "cache"),
@@ -212,7 +210,7 @@ class NativeExtensionCacheTest < Minitest::Test
 
       # Restore to work directory
       work_dir = File.join(tmpdir, "work")
-      FileUtils.mkdir_p(work_dir)
+      tmpdir << "work/"
 
       restored_exts = cache.restore(work_dir)
 
@@ -237,8 +235,7 @@ class NativeExtensionCacheTest < Minitest::Test
 
       # Create work directory with existing files
       work_dir = File.join(tmpdir, "work")
-      FileUtils.mkdir_p(File.join(work_dir, "ext", "old_gem"))
-      File.write(File.join(work_dir, "ext", "old_gem", "old.o"), "old content")
+      tmpdir << ["work/ext/old_gem/old.o", "old content"]
 
       cache.restore(work_dir)
 
@@ -283,13 +280,10 @@ class NativeExtensionCacheTest < Minitest::Test
   def test_save_copies_ports_directories
     with_tmpdir do |tmpdir|
       work_dir = File.join(tmpdir, "work")
-      FileUtils.mkdir_p(File.join(work_dir, "ext", "nokogiri"))
-      File.write(File.join(work_dir, "ext", "nokogiri", "nokogiri.o"), "object file content")
+      tmpdir << ["work/ext/nokogiri/nokogiri.o", "object file content"]
 
       # Create ports directory structure like nokogiri
-      ports_dir = File.join(work_dir, "bundle/ruby/3.4.0/gems/nokogiri-1.19.0/ports/x86_64-darwin/libxml2/2.12.0/lib")
-      FileUtils.mkdir_p(ports_dir)
-      File.write(File.join(ports_dir, "libxml2.a"), "static lib content")
+      tmpdir << ["work/bundle/ruby/3.4.0/gems/nokogiri-1.19.0/ports/x86_64-darwin/libxml2/2.12.0/lib/libxml2.a", "static lib content"]
 
       cache = Kompo::NativeExtensionCache.new(
         cache_dir: File.join(tmpdir, "cache"),
@@ -336,7 +330,7 @@ class NativeExtensionCacheTest < Minitest::Test
       # Create work directory with bundle structure (simulating BundleCache restore)
       work_dir = File.join(tmpdir, "work")
       gem_dir = File.join(work_dir, "bundle/ruby/3.4.0/gems/nokogiri-1.19.0")
-      FileUtils.mkdir_p(gem_dir)
+      tmpdir << "work/bundle/ruby/3.4.0/gems/nokogiri-1.19.0/"
 
       # Restore
       cache.restore(work_dir)
@@ -364,7 +358,7 @@ class NativeExtensionCacheTest < Minitest::Test
       File.write(File.join(cache.cache_dir, "metadata.json"), JSON.generate({"exts" => []}))
 
       work_dir = File.join(tmpdir, "work")
-      FileUtils.mkdir_p(work_dir)
+      tmpdir << "work/"
 
       # Should not raise
       cache.restore(work_dir)
@@ -396,7 +390,7 @@ class NativeExtensionCacheTest < Minitest::Test
 
       # Create work directory WITHOUT the nokogiri gem
       work_dir = File.join(tmpdir, "work")
-      FileUtils.mkdir_p(work_dir)
+      tmpdir << "work/"
 
       # Should not raise even though gem directory doesn't exist
       cache.restore(work_dir)
@@ -411,16 +405,12 @@ class NativeExtensionCacheTest < Minitest::Test
       work_dir = File.join(tmpdir, "work")
 
       # Create nested ports (like nokogiri's libgumbo in ext/nokogiri/ports)
-      nested_ports = File.join(work_dir, "bundle/ruby/3.4.0/gems/nokogiri-1.19.0/ext/nokogiri/ports/arm64-darwin/libgumbo/lib")
-      FileUtils.mkdir_p(nested_ports)
-      File.write(File.join(nested_ports, "libgumbo.a"), "fake lib")
+      tmpdir << ["work/bundle/ruby/3.4.0/gems/nokogiri-1.19.0/ext/nokogiri/ports/arm64-darwin/libgumbo/lib/libgumbo.a", "fake lib"]
 
       # Create ext directory
-      ext_dir = File.join(work_dir, "ext/nokogiri")
-      FileUtils.mkdir_p(ext_dir)
-      File.write(File.join(ext_dir, "nokogiri.o"), "fake object")
+      tmpdir << ["work/ext/nokogiri/nokogiri.o", "fake object"]
 
-      File.write(File.join(work_dir, "Gemfile.lock"), "GEM\n  specs:\n    nokogiri (1.19.0)\n")
+      tmpdir << ["work/Gemfile.lock", "GEM\n  specs:\n    nokogiri (1.19.0)\n"]
 
       cache = Kompo::NativeExtensionCache.from_work_dir(
         cache_dir: File.join(tmpdir, "cache"),
@@ -432,7 +422,7 @@ class NativeExtensionCacheTest < Minitest::Test
 
       # Restore to new work_dir
       new_work_dir = File.join(tmpdir, "new_work")
-      FileUtils.mkdir_p(File.join(new_work_dir, "bundle/ruby/3.4.0/gems/nokogiri-1.19.0/ext/nokogiri"))
+      tmpdir << "new_work/bundle/ruby/3.4.0/gems/nokogiri-1.19.0/ext/nokogiri/"
 
       cache.restore(new_work_dir)
 

--- a/test/packing_cache_test.rb
+++ b/test/packing_cache_test.rb
@@ -17,7 +17,7 @@ class PackingCacheTest < Minitest::Test
   def test_from_work_dir_creates_cache_instance
     with_tmpdir do |tmpdir|
       gemfile_lock_content = "GEM\n  specs:\n"
-      File.write(File.join(tmpdir, "Gemfile.lock"), gemfile_lock_content)
+      tmpdir << ["Gemfile.lock", gemfile_lock_content]
 
       cache = Kompo::PackingCache.from_work_dir(
         cache_dir: "/tmp/cache",

--- a/test/tasks/check_stdlibs_test.rb
+++ b/test/tasks/check_stdlibs_test.rb
@@ -8,21 +8,19 @@ class CheckStdlibsTest < Minitest::Test
 
   def test_check_stdlibs_accesses_install_ruby
     with_tmpdir do |tmpdir|
-      stdlib_root = File.join(tmpdir, "lib", "ruby", "3.4.0")
-      FileUtils.mkdir_p(stdlib_root)
+      tmpdir << "lib/ruby/3.4.0/"
       mock_install_ruby_with_dir(tmpdir)
 
       paths = Kompo::CheckStdlibs.paths
 
-      assert_includes paths, stdlib_root
+      assert_includes paths, File.join(tmpdir, "lib", "ruby", "3.4.0")
       assert_task_accessed(Kompo::InstallRuby, :ruby_install_dir)
     end
   end
 
   def test_check_stdlibs_skips_when_no_stdlib_flag_set
     with_tmpdir do |tmpdir|
-      stdlib_root = File.join(tmpdir, "lib", "ruby", "3.4.0")
-      FileUtils.mkdir_p(stdlib_root)
+      tmpdir << "lib/ruby/3.4.0/"
       mock_install_ruby_with_dir(tmpdir)
       mock_args(no_stdlib: true)
 
@@ -34,15 +32,14 @@ class CheckStdlibsTest < Minitest::Test
 
   def test_check_stdlibs_includes_gem_specifications
     with_tmpdir do |tmpdir|
-      stdlib_root = File.join(tmpdir, "lib", "ruby", "3.4.0")
-      gems_specs = File.join(tmpdir, "lib", "ruby", "gems", "3.4.0", "specifications")
-      FileUtils.mkdir_p([stdlib_root, gems_specs])
+      tmpdir << "lib/ruby/3.4.0/" \
+             << "lib/ruby/gems/3.4.0/specifications/"
       mock_install_ruby_with_dir(tmpdir)
 
       paths = Kompo::CheckStdlibs.paths
 
-      assert_includes paths, stdlib_root
-      assert_includes paths, gems_specs
+      assert_includes paths, File.join(tmpdir, "lib", "ruby", "3.4.0")
+      assert_includes paths, File.join(tmpdir, "lib", "ruby", "gems", "3.4.0", "specifications")
     end
   end
 

--- a/test/tasks/collect_dependencies_test.rb
+++ b/test/tasks/collect_dependencies_test.rb
@@ -8,10 +8,10 @@ class CollectDependenciesTest < Minitest::Test
 
   def test_collect_dependencies_output_path_in_directory
     with_tmpdir do |tmpdir|
+      tmpdir << "work/" << "myproject/" << "output/"
       work_dir = File.join(tmpdir, "work")
       project_dir = File.join(tmpdir, "myproject")
       output_dir = File.join(tmpdir, "output")
-      FileUtils.mkdir_p([work_dir, project_dir, output_dir])
 
       # Mock all dependencies
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
@@ -36,10 +36,10 @@ class CollectDependenciesTest < Minitest::Test
 
   def test_collect_dependencies_output_path_as_file
     with_tmpdir do |tmpdir|
+      tmpdir << "work/" << "myproject/"
       work_dir = File.join(tmpdir, "work")
       project_dir = File.join(tmpdir, "myproject")
       output_file = File.join(tmpdir, "mybinary")
-      FileUtils.mkdir_p([work_dir, project_dir])
 
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
       mock_task(Kompo::InstallRuby,
@@ -63,10 +63,10 @@ class CollectDependenciesTest < Minitest::Test
 
   def test_collect_dependencies_collects_all_dependencies
     with_tmpdir do |tmpdir|
+      tmpdir << "work/" << "myproject/" << "output/"
       work_dir = File.join(tmpdir, "work")
       project_dir = File.join(tmpdir, "myproject")
       output_dir = File.join(tmpdir, "output")
-      FileUtils.mkdir_p([work_dir, project_dir, output_dir])
 
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
       mock_task(Kompo::InstallRuby,

--- a/test/tasks/copy_files_test.rb
+++ b/test/tasks/copy_files_test.rb
@@ -8,13 +8,11 @@ class CopyGemfileTest < Minitest::Test
 
   def test_copy_gemfile_returns_false_when_no_gemfile
     with_tmpdir do |tmpdir|
-      work_dir = File.join(tmpdir, "work")
-      project_dir = File.join(tmpdir, "project")
-      FileUtils.mkdir_p([work_dir, project_dir])
+      tmpdir << "work/" << "project/"
       # No Gemfile in project_dir
 
-      mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
-      mock_args(project_dir: project_dir)
+      mock_task(Kompo::WorkDir, path: File.join(tmpdir, "work"), original_dir: tmpdir)
+      mock_args(project_dir: File.join(tmpdir, "project"))
 
       refute Kompo::CopyGemfile.gemfile_exists
     end
@@ -22,14 +20,11 @@ class CopyGemfileTest < Minitest::Test
 
   def test_copy_gemfile_returns_true_when_gemfile_exists
     with_tmpdir do |tmpdir|
-      work_dir = File.join(tmpdir, "work")
-      project_dir = File.join(tmpdir, "project")
-      FileUtils.mkdir_p([work_dir, project_dir])
-      # Create Gemfile in project_dir
-      File.write(File.join(project_dir, "Gemfile"), "source 'https://rubygems.org'")
+      tmpdir << "work/" << ["project/Gemfile", "source 'https://rubygems.org'"]
 
+      work_dir = File.join(tmpdir, "work")
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
-      mock_args(project_dir: project_dir)
+      mock_args(project_dir: File.join(tmpdir, "project"))
 
       assert Kompo::CopyGemfile.gemfile_exists
       # Verify Gemfile was copied to work_dir
@@ -39,15 +34,13 @@ class CopyGemfileTest < Minitest::Test
 
   def test_copy_gemfile_also_copies_gemfile_lock
     with_tmpdir do |tmpdir|
-      work_dir = File.join(tmpdir, "work")
-      project_dir = File.join(tmpdir, "project")
-      FileUtils.mkdir_p([work_dir, project_dir])
-      # Create both Gemfile and Gemfile.lock in project_dir
-      File.write(File.join(project_dir, "Gemfile"), "source 'https://rubygems.org'")
-      File.write(File.join(project_dir, "Gemfile.lock"), "GEM\n  remote: https://rubygems.org/\n")
+      tmpdir << "work/" \
+             << ["project/Gemfile", "source 'https://rubygems.org'"] \
+             << ["project/Gemfile.lock", "GEM\n  remote: https://rubygems.org/\n"]
 
+      work_dir = File.join(tmpdir, "work")
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
-      mock_args(project_dir: project_dir)
+      mock_args(project_dir: File.join(tmpdir, "project"))
 
       assert Kompo::CopyGemfile.gemfile_exists
       # Verify both files were copied to work_dir
@@ -58,15 +51,13 @@ class CopyGemfileTest < Minitest::Test
 
   def test_copy_gemfile_copies_gemspec_when_gemfile_references_gemspec
     with_tmpdir do |tmpdir|
-      work_dir = File.join(tmpdir, "work")
-      project_dir = File.join(tmpdir, "project")
-      FileUtils.mkdir_p([work_dir, project_dir])
-      # Create Gemfile with gemspec directive
-      File.write(File.join(project_dir, "Gemfile"), "source 'https://rubygems.org'\ngemspec")
-      File.write(File.join(project_dir, "my_gem.gemspec"), "Gem::Specification.new { |s| s.name = 'my_gem' }")
+      tmpdir << "work/" \
+             << ["project/Gemfile", "source 'https://rubygems.org'\ngemspec"] \
+             << ["project/my_gem.gemspec", "Gem::Specification.new { |s| s.name = 'my_gem' }"]
 
+      work_dir = File.join(tmpdir, "work")
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
-      mock_args(project_dir: project_dir)
+      mock_args(project_dir: File.join(tmpdir, "project"))
 
       assert Kompo::CopyGemfile.gemfile_exists
       # Verify Gemfile and gemspec were copied to work_dir
@@ -77,15 +68,13 @@ class CopyGemfileTest < Minitest::Test
 
   def test_copy_gemfile_does_not_copy_gemspec_when_no_gemspec_directive
     with_tmpdir do |tmpdir|
-      work_dir = File.join(tmpdir, "work")
-      project_dir = File.join(tmpdir, "project")
-      FileUtils.mkdir_p([work_dir, project_dir])
-      # Create Gemfile without gemspec directive
-      File.write(File.join(project_dir, "Gemfile"), "source 'https://rubygems.org'\ngem 'rake'")
-      File.write(File.join(project_dir, "my_gem.gemspec"), "Gem::Specification.new { |s| s.name = 'my_gem' }")
+      tmpdir << "work/" \
+             << ["project/Gemfile", "source 'https://rubygems.org'\ngem 'rake'"] \
+             << ["project/my_gem.gemspec", "Gem::Specification.new { |s| s.name = 'my_gem' }"]
 
+      work_dir = File.join(tmpdir, "work")
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
-      mock_args(project_dir: project_dir)
+      mock_args(project_dir: File.join(tmpdir, "project"))
 
       assert Kompo::CopyGemfile.gemfile_exists
       # Verify Gemfile was copied but gemspec was not
@@ -96,16 +85,14 @@ class CopyGemfileTest < Minitest::Test
 
   def test_copy_gemfile_copies_multiple_gemspecs
     with_tmpdir do |tmpdir|
-      work_dir = File.join(tmpdir, "work")
-      project_dir = File.join(tmpdir, "project")
-      FileUtils.mkdir_p([work_dir, project_dir])
-      # Create Gemfile with gemspec directive and multiple gemspecs
-      File.write(File.join(project_dir, "Gemfile"), "gemspec")
-      File.write(File.join(project_dir, "my_gem.gemspec"), "Gem::Specification.new { |s| s.name = 'my_gem' }")
-      File.write(File.join(project_dir, "other_gem.gemspec"), "Gem::Specification.new { |s| s.name = 'other_gem' }")
+      tmpdir << "work/" \
+             << ["project/Gemfile", "gemspec"] \
+             << ["project/my_gem.gemspec", "Gem::Specification.new { |s| s.name = 'my_gem' }"] \
+             << ["project/other_gem.gemspec", "Gem::Specification.new { |s| s.name = 'other_gem' }"]
 
+      work_dir = File.join(tmpdir, "work")
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
-      mock_args(project_dir: project_dir)
+      mock_args(project_dir: File.join(tmpdir, "project"))
 
       assert Kompo::CopyGemfile.gemfile_exists
       # Verify all gemspecs were copied
@@ -116,14 +103,11 @@ class CopyGemfileTest < Minitest::Test
 
   def test_copy_gemfile_skips_when_no_gemfile_option_specified
     with_tmpdir do |tmpdir|
-      work_dir = File.join(tmpdir, "work")
-      project_dir = File.join(tmpdir, "project")
-      FileUtils.mkdir_p([work_dir, project_dir])
-      # Create Gemfile in project_dir
-      File.write(File.join(project_dir, "Gemfile"), "source 'https://rubygems.org'")
+      tmpdir << "work/" << ["project/Gemfile", "source 'https://rubygems.org'"]
 
+      work_dir = File.join(tmpdir, "work")
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
-      mock_args(project_dir: project_dir, no_gemfile: true)
+      mock_args(project_dir: File.join(tmpdir, "project"), no_gemfile: true)
 
       # gemfile_exists should be false even though Gemfile exists
       refute Kompo::CopyGemfile.gemfile_exists
@@ -139,13 +123,10 @@ class CopyProjectFilesTest < Minitest::Test
 
   def test_copy_project_files_copies_entrypoint
     with_tmpdir do |tmpdir|
+      tmpdir << "work/" << ["project/main.rb", "puts 'hello'"]
+
       work_dir = File.join(tmpdir, "work")
       project_dir = File.join(tmpdir, "project")
-      FileUtils.mkdir_p([work_dir, project_dir])
-
-      # Create entrypoint in project_dir
-      File.write(File.join(project_dir, "main.rb"), "puts 'hello'")
-
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
       mock_args(project_dir: project_dir, entrypoint: "main.rb", files: [])
 
@@ -162,15 +143,12 @@ class CopyProjectFilesTest < Minitest::Test
 
   def test_copy_project_files_copies_additional_files
     with_tmpdir do |tmpdir|
+      tmpdir << "work/" \
+             << ["project/main.rb", "require_relative 'lib/app'"] \
+             << ["project/lib/app.rb", "class App; end"]
+
       work_dir = File.join(tmpdir, "work")
       project_dir = File.join(tmpdir, "project")
-      lib_dir = File.join(project_dir, "lib")
-      FileUtils.mkdir_p([work_dir, lib_dir])
-
-      # Create files in project_dir
-      File.write(File.join(project_dir, "main.rb"), "require_relative 'lib/app'")
-      File.write(File.join(lib_dir, "app.rb"), "class App; end")
-
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
       mock_args(project_dir: project_dir, entrypoint: "main.rb", files: ["lib"])
 
@@ -186,15 +164,12 @@ class CopyProjectFilesTest < Minitest::Test
 
   def test_copy_project_files_copies_individual_files
     with_tmpdir do |tmpdir|
+      tmpdir << "work/" \
+             << ["project/main.rb", "require_relative 'config/settings'"] \
+             << ["project/config/settings.rb", "SETTINGS = {}"]
+
       work_dir = File.join(tmpdir, "work")
       project_dir = File.join(tmpdir, "project")
-      config_dir = File.join(project_dir, "config")
-      FileUtils.mkdir_p([work_dir, config_dir])
-
-      # Create files in project_dir (individual file, not directory)
-      File.write(File.join(project_dir, "main.rb"), "require_relative 'config/settings'")
-      File.write(File.join(config_dir, "settings.rb"), "SETTINGS = {}")
-
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
       mock_args(project_dir: project_dir, entrypoint: "main.rb", files: ["config/settings.rb"])
 
@@ -210,16 +185,13 @@ class CopyProjectFilesTest < Minitest::Test
 
   def test_copy_project_files_with_dot_copies_directory_contents
     with_tmpdir do |tmpdir|
+      tmpdir << "work/" \
+             << ["project/main.rb", "puts 'hello'"] \
+             << ["project/app.gemspec", "Gem::Specification.new { |s| s.name = 'app' }"] \
+             << ["project/lib/app.rb", "class App; end"]
+
       work_dir = File.join(tmpdir, "work")
       project_dir = File.join(tmpdir, "project")
-      lib_dir = File.join(project_dir, "lib")
-      FileUtils.mkdir_p([work_dir, lib_dir])
-
-      # Create files in project_dir
-      File.write(File.join(project_dir, "main.rb"), "puts 'hello'")
-      File.write(File.join(project_dir, "app.gemspec"), "Gem::Specification.new { |s| s.name = 'app' }")
-      File.write(File.join(lib_dir, "app.rb"), "class App; end")
-
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
       mock_args(project_dir: project_dir, entrypoint: "main.rb", files: ["."])
 

--- a/test/tasks/packing_test.rb
+++ b/test/tasks/packing_test.rb
@@ -34,22 +34,20 @@ class PackingForMacOSDryRunTest < Minitest::Test
 
     with_tmpdir do |tmpdir|
       work_dir = tmpdir
-      ruby_build_dir = File.join(tmpdir, "ruby-build", "ruby-3.4.1")
       ruby_install_dir = File.join(tmpdir, "ruby-install")
       kompo_lib = File.join(tmpdir, "kompo-lib")
       output_path = File.join(tmpdir, "output", "myapp")
 
-      # Create required directories
-      FileUtils.mkdir_p(ruby_build_dir)
-      FileUtils.mkdir_p(File.join(ruby_install_dir, "lib", "pkgconfig"))
-      FileUtils.mkdir_p(File.join(tmpdir, "output"))
-      FileUtils.mkdir_p(kompo_lib)
+      # Create required directories and files
+      tmpdir << "ruby-build/ruby-3.4.1/" \
+             << "ruby-install/lib/pkgconfig/" \
+             << "output/" \
+             << "kompo-lib/" \
+             << ["main.c", "int main() { return 0; }"] \
+             << ["fs.c", "// fs"]
 
-      # Create main.c and fs.c files
       main_c = File.join(tmpdir, "main.c")
       fs_c = File.join(tmpdir, "fs.c")
-      File.write(main_c, "int main() { return 0; }")
-      File.write(fs_c, "// fs")
 
       # Mock CollectDependencies
       deps = Kompo::CollectDependencies::Dependencies.new(
@@ -108,22 +106,20 @@ class PackingForLinuxDryRunTest < Minitest::Test
 
     with_tmpdir do |tmpdir|
       work_dir = tmpdir
-      ruby_build_dir = File.join(tmpdir, "ruby-build", "ruby-3.4.1")
       ruby_install_dir = File.join(tmpdir, "ruby-install")
       kompo_lib = File.join(tmpdir, "kompo-lib")
       output_path = File.join(tmpdir, "output", "myapp")
 
-      # Create required directories
-      FileUtils.mkdir_p(ruby_build_dir)
-      FileUtils.mkdir_p(File.join(ruby_install_dir, "lib", "pkgconfig"))
-      FileUtils.mkdir_p(File.join(tmpdir, "output"))
-      FileUtils.mkdir_p(kompo_lib)
+      # Create required directories and files
+      tmpdir << "ruby-build/ruby-3.4.1/" \
+             << "ruby-install/lib/pkgconfig/" \
+             << "output/" \
+             << "kompo-lib/" \
+             << ["main.c", "int main() { return 0; }"] \
+             << ["fs.c", "// fs"]
 
-      # Create main.c and fs.c files
       main_c = File.join(tmpdir, "main.c")
       fs_c = File.join(tmpdir, "fs.c")
-      File.write(main_c, "int main() { return 0; }")
-      File.write(fs_c, "// fs")
 
       # Mock CollectDependencies
       deps = Kompo::CollectDependencies::Dependencies.new(

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -79,8 +79,10 @@ class TmpDir
     when String
       [entry, nil]
     when Array
-      raise ArgumentError, "expected 1 or 2 elements, got #{entry.size}" if entry.size > 2
+      raise ArgumentError, "expected 1 or 2 elements, got #{entry.size}" if entry.size == 0 || entry.size > 2
       entry
+    else
+      raise ArgumentError, "expected String or Array, got #{entry.class}"
     end
   end
 end

--- a/test/tmp_dir_test.rb
+++ b/test/tmp_dir_test.rb
@@ -88,6 +88,20 @@ class TmpDirTest < Minitest::Test
     end
   end
 
+  def test_shovel_empty_array_raises_error
+    with_tmpdir do |tmpdir|
+      assert_raises(ArgumentError) { tmpdir << [] }
+    end
+  end
+
+  def test_shovel_unsupported_type_raises_error
+    with_tmpdir do |tmpdir|
+      assert_raises(ArgumentError) { tmpdir << 123 }
+      assert_raises(ArgumentError) { tmpdir << nil }
+      assert_raises(ArgumentError) { tmpdir << {name: "file"} }
+    end
+  end
+
   def test_shovel_returns_self_for_chaining
     with_tmpdir do |tmpdir|
       tmpdir << "a.txt" << ["b.txt", "B"] << "subdir/"

--- a/test/tmp_dir_test.rb
+++ b/test/tmp_dir_test.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class TmpDirTest < Minitest::Test
+  def test_to_s_returns_path
+    with_tmpdir do |tmpdir|
+      assert_kind_of String, tmpdir.to_s
+      assert Dir.exist?(tmpdir.to_s)
+    end
+  end
+
+  def test_works_with_file_join
+    with_tmpdir do |tmpdir|
+      path = File.join(tmpdir, "foo")
+      assert path.end_with?("/foo")
+    end
+  end
+
+  def test_shovel_string_creates_empty_file
+    with_tmpdir do |tmpdir|
+      tmpdir << "empty.txt"
+      assert File.exist?(File.join(tmpdir, "empty.txt"))
+      assert_equal "", File.read(File.join(tmpdir, "empty.txt"))
+    end
+  end
+
+  def test_shovel_array_creates_file_with_content
+    with_tmpdir do |tmpdir|
+      tmpdir << ["hello.txt", "hello world"]
+      assert_equal "hello world", File.read(File.join(tmpdir, "hello.txt"))
+    end
+  end
+
+  def test_shovel_string_with_trailing_slash_creates_directory
+    with_tmpdir do |tmpdir|
+      tmpdir << "subdir/"
+      assert Dir.exist?(File.join(tmpdir, "subdir"))
+    end
+  end
+
+  def test_shovel_nested_path_creates_parent_dirs
+    with_tmpdir do |tmpdir|
+      tmpdir << ["deep/nested/file.txt", "content"]
+      assert_equal "content", File.read(File.join(tmpdir, "deep/nested/file.txt"))
+    end
+  end
+
+  def test_shovel_nested_empty_file_creates_parent_dirs
+    with_tmpdir do |tmpdir|
+      tmpdir << "deep/nested/empty.txt"
+      assert File.exist?(File.join(tmpdir, "deep/nested/empty.txt"))
+    end
+  end
+
+  def test_shovel_nested_directory_creates_full_path
+    with_tmpdir do |tmpdir|
+      tmpdir << "a/b/c/"
+      assert Dir.exist?(File.join(tmpdir, "a/b/c"))
+    end
+  end
+
+  def test_shovel_single_element_array_creates_empty_file
+    with_tmpdir do |tmpdir|
+      tmpdir << ["empty.txt"]
+      assert File.exist?(File.join(tmpdir, "empty.txt"))
+      assert_equal "", File.read(File.join(tmpdir, "empty.txt"))
+    end
+  end
+
+  def test_shovel_single_element_array_with_trailing_slash_creates_directory
+    with_tmpdir do |tmpdir|
+      tmpdir << ["subdir/"]
+      assert Dir.exist?(File.join(tmpdir, "subdir"))
+    end
+  end
+
+  def test_shovel_single_element_array_with_nested_path_creates_parent_dirs
+    with_tmpdir do |tmpdir|
+      tmpdir << ["deep/nested/empty.txt"]
+      assert File.exist?(File.join(tmpdir, "deep/nested/empty.txt"))
+    end
+  end
+
+  def test_shovel_array_with_three_or_more_elements_raises_error
+    with_tmpdir do |tmpdir|
+      assert_raises(ArgumentError) { tmpdir << ["a.txt", "content", "extra"] }
+    end
+  end
+
+  def test_shovel_returns_self_for_chaining
+    with_tmpdir do |tmpdir|
+      tmpdir << "a.txt" << ["b.txt", "B"] << "subdir/"
+      assert File.exist?(File.join(tmpdir, "a.txt"))
+      assert_equal "B", File.read(File.join(tmpdir, "b.txt"))
+      assert Dir.exist?(File.join(tmpdir, "subdir"))
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `TmpDir` wrapper class to `with_tmpdir` that supports `#<<` operator for declarative file/directory creation in tests
- Rewrite 15 test files to use the new `TmpDir#<<` syntax, reducing ~200 lines of boilerplate (`FileUtils.mkdir_p` / `File.write` patterns)

### TmpDir#<< usage
```ruby
with_tmpdir do |tmpdir|
  tmpdir << "dir/"                          # create directory
  tmpdir << "empty.txt"                     # create empty file
  tmpdir << ["file.txt", "content"]         # create file with content
  tmpdir << "a/" << ["b.txt", "B"]          # chaining
end
```

## Test plan
- [x] All 321 tests pass
- [x] standardrb lint clean
- [x] TmpDir class has its own test file (`test/tmp_dir_test.rb`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a temporary-directory helper to simplify building test fixtures, enabling concise creation of files and directories.
  * Migrated many tests to use the new helper, reducing boilerplate and improving consistency across the test suite.
  * Added a test suite validating the helper's behavior (file/dir creation, content writing, chaining, and error cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->