### PR TITLE
Replace mock_args with Task.value(args:) pattern

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 13.0"
-gem "taski", "~> 0.9.1"
+gem "taski", "~> 0.10.0"
 
 group :development, :test do
   gem "debug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
       rubocop-performance (~> 1.26.0)
     stringio (3.2.0)
     strscan (3.1.7)
-    taski (0.9.2)
+    taski (0.10.0)
       base64
       liquid (~> 5.0)
       prism (~> 1.4)
@@ -148,7 +148,7 @@ DEPENDENCIES
   rake (~> 13.0)
   simplecov
   standard
-  taski (~> 0.9.1)
+  taski (~> 0.10.0)
   webmock
 
 BUNDLED WITH

--- a/exe/kompo
+++ b/exe/kompo
@@ -64,6 +64,8 @@ opt.parse!(ARGV)
 args[:files] = ARGV
 
 Kompo.configure_progress(args.delete(:progress))
+Kompo::CommandRunner.verbose = args[:verbose]
+Kompo::CommandRunner.dry_run = args[:dry_run]
 
 if args[:init]
   project_dir = Dir.pwd

--- a/lib/kompo/command_runner.rb
+++ b/lib/kompo/command_runner.rb
@@ -39,6 +39,13 @@ module Kompo
     end
 
     class << self
+      attr_writer :verbose, :dry_run
+
+      def reset_options!
+        @verbose = nil
+        @dry_run = nil
+      end
+
       # Capture stdout (replacement for backticks and Open3.capture2)
       # @param command [Array<String>] Command and arguments
       # @param chdir [String, nil] Working directory
@@ -169,11 +176,11 @@ module Kompo
       private
 
       def verbose?
-        defined?(Taski) && Taski.args&.[](:verbose)
+        @verbose
       end
 
       def dry_run?
-        defined?(Taski) && Taski.args&.[](:dry_run)
+        @dry_run
       end
 
       def log_command(command)

--- a/test/command_runner_test.rb
+++ b/test/command_runner_test.rb
@@ -235,12 +235,15 @@ class CommandRunnerWhichTest < Minitest::Test
 end
 
 class CommandRunnerDryRunTest < Minitest::Test
-  include Taski::TestHelper::Minitest
-  include TaskTestHelpers
+  def setup
+    Kompo::CommandRunner.dry_run = true
+  end
+
+  def teardown
+    Kompo::CommandRunner.reset_options!
+  end
 
   def test_capture_in_dry_run_mode_does_not_execute
-    mock_args(dry_run: true)
-
     # This would fail if actually executed
     result = Kompo::CommandRunner.capture("nonexistent_command_that_would_fail")
 
@@ -250,8 +253,6 @@ class CommandRunnerDryRunTest < Minitest::Test
   end
 
   def test_capture_all_in_dry_run_mode_does_not_execute
-    mock_args(dry_run: true)
-
     result = Kompo::CommandRunner.capture_all("nonexistent_command_that_would_fail")
 
     assert result.success?
@@ -259,8 +260,6 @@ class CommandRunnerDryRunTest < Minitest::Test
   end
 
   def test_run_in_dry_run_mode_does_not_execute
-    mock_args(dry_run: true)
-
     # This would fail if actually executed
     result = Kompo::CommandRunner.run("nonexistent_command_that_would_fail")
 
@@ -269,8 +268,6 @@ class CommandRunnerDryRunTest < Minitest::Test
   end
 
   def test_which_in_dry_run_mode_returns_nil
-    mock_args(dry_run: true)
-
     result = Kompo::CommandRunner.which("any_command")
 
     # In dry-run mode, which returns nil
@@ -279,12 +276,15 @@ class CommandRunnerDryRunTest < Minitest::Test
 end
 
 class CommandRunnerVerboseTest < Minitest::Test
-  include Taski::TestHelper::Minitest
-  include TaskTestHelpers
+  def setup
+    Kompo::CommandRunner.verbose = true
+  end
+
+  def teardown
+    Kompo::CommandRunner.reset_options!
+  end
 
   def test_capture_in_verbose_mode_outputs_command
-    mock_args(verbose: true)
-
     output = capture_io do
       Kompo::CommandRunner.capture("echo", "hello")
     end
@@ -294,8 +294,6 @@ class CommandRunnerVerboseTest < Minitest::Test
   end
 
   def test_run_in_verbose_mode_outputs_command
-    mock_args(verbose: true)
-
     output = capture_io do
       Kompo::CommandRunner.run("true")
     end
@@ -305,8 +303,6 @@ class CommandRunnerVerboseTest < Minitest::Test
   end
 
   def test_run_failure_in_verbose_mode_outputs_fail
-    mock_args(verbose: true)
-
     output = capture_io do
       Kompo::CommandRunner.run("false")
     end
@@ -316,8 +312,6 @@ class CommandRunnerVerboseTest < Minitest::Test
   end
 
   def test_capture_failure_in_verbose_mode_outputs_exit_code
-    mock_args(verbose: true)
-
     output = capture_io do
       Kompo::CommandRunner.capture("sh", "-c", "exit 42")
     end

--- a/test/tasks/bundle_install_test.rb
+++ b/test/tasks/bundle_install_test.rb
@@ -54,10 +54,8 @@ class BundleInstallTest < Minitest::Test
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
       mock_task(Kompo::CopyGemfile, gemfile_exists: true)
       mock_task(Kompo::InstallRuby, ruby_version: "3.4.1", ruby_major_minor: "3.4")
-      mock_args(cache_dir: File.join(tmpdir, ".kompo", "cache"))
-
       # Execute and verify FromCache was selected (it restores bundle directory)
-      Kompo::BundleInstall.bundle_ruby_dir
+      Kompo::BundleInstall.bundle_ruby_dir(args: {cache_dir: File.join(tmpdir, ".kompo", "cache")})
       assert Dir.exist?(File.join(work_dir, "bundle")), "FromCache should restore bundle directory"
     end
   end
@@ -79,9 +77,7 @@ class BundleInstallTest < Minitest::Test
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
       mock_task(Kompo::CopyGemfile, gemfile_exists: true)
       mock_task(Kompo::InstallRuby, ruby_version: "3.4.1", ruby_major_minor: "3.4")
-      mock_args(cache_dir: File.join(tmpdir, ".kompo", "cache"))
-
-      bundle_ruby_dir = Kompo::BundleInstall.bundle_ruby_dir
+      bundle_ruby_dir = Kompo::BundleInstall.bundle_ruby_dir(args: {cache_dir: File.join(tmpdir, ".kompo", "cache")})
 
       # Verify cache was restored
       assert Dir.exist?(File.join(work_dir, "bundle"))
@@ -146,8 +142,6 @@ class BundleInstallParseVersionTest < Minitest::Test
         ruby_install_dir: ruby_install_dir,
         ruby_version: "3.4.1",
         ruby_major_minor: "3.4")
-      mock_args(cache_dir: File.join(tmpdir, ".kompo", "cache"), no_cache: true)
-
       # Mock bundler config set and install
       @mock.stub([ruby_path, bundler_path, "config", "set", "--local", "path", "bundle"],
         output: "", success: true)
@@ -158,7 +152,7 @@ class BundleInstallParseVersionTest < Minitest::Test
 
       tmpdir << "work/bundle/ruby/3.4.0/" << ["work/.bundle/config", "BUNDLE_PATH: bundle"]
 
-      capture_io { Kompo::BundleInstall.run }
+      capture_io { Kompo::BundleInstall.run(args: {cache_dir: File.join(tmpdir, ".kompo", "cache"), no_cache: true}) }
 
       # Should NOT attempt to check or install bundler (invalid version skipped)
       gem_path = File.join(ruby_install_dir, "bin", "gem")
@@ -204,8 +198,6 @@ class BundleInstallFromSourceTest < Minitest::Test
         ruby_install_dir: ruby_install_dir,
         ruby_version: "3.4.1",
         ruby_major_minor: "3.4")
-      mock_args(cache_dir: File.join(tmpdir, ".kompo", "cache"), no_cache: true)
-
       # Mock: get current bundler version (different from BUNDLED WITH)
       @mock.stub([ruby_path, "-e", "require 'bundler'; puts Bundler::VERSION"],
         output: "2.6.9", success: true)
@@ -226,7 +218,7 @@ class BundleInstallFromSourceTest < Minitest::Test
       # Create expected directory structure
       tmpdir << "work/bundle/ruby/3.4.0/" << ["work/.bundle/config", "BUNDLE_PATH: bundle"]
 
-      capture_io { Kompo::BundleInstall.run }
+      capture_io { Kompo::BundleInstall.run(args: {cache_dir: File.join(tmpdir, ".kompo", "cache"), no_cache: true}) }
 
       assert @mock.called?(:run, ruby_path, gem_path, "install", "bundler", "-v", "2.5.0"),
         "Should install bundler matching BUNDLED WITH version"
@@ -253,8 +245,6 @@ class BundleInstallFromSourceTest < Minitest::Test
         ruby_install_dir: ruby_install_dir,
         ruby_version: "3.4.1",
         ruby_major_minor: "3.4")
-      mock_args(cache_dir: File.join(tmpdir, ".kompo", "cache"), no_cache: true)
-
       # Mock: get current bundler version (same as BUNDLED WITH)
       @mock.stub([ruby_path, "-e", "require 'bundler'; puts Bundler::VERSION"],
         output: "2.6.9", success: true)
@@ -270,7 +260,7 @@ class BundleInstallFromSourceTest < Minitest::Test
       # Create expected directory structure
       tmpdir << "work/bundle/ruby/3.4.0/" << ["work/.bundle/config", "BUNDLE_PATH: bundle"]
 
-      capture_io { Kompo::BundleInstall.run }
+      capture_io { Kompo::BundleInstall.run(args: {cache_dir: File.join(tmpdir, ".kompo", "cache"), no_cache: true}) }
 
       gem_path = File.join(ruby_install_dir, "bin", "gem")
       refute @mock.called?(:run, ruby_path, gem_path, "install", "bundler", "-v", "2.6.9"),
@@ -299,8 +289,6 @@ class BundleInstallFromSourceTest < Minitest::Test
         ruby_install_dir: ruby_install_dir,
         ruby_version: "3.4.1",
         ruby_major_minor: "3.4")
-      mock_args(cache_dir: File.join(tmpdir, ".kompo", "cache"), no_cache: true)
-
       # Mock bundler config set and install
       @mock.stub([ruby_path, bundler_path, "config", "set", "--local", "path", "bundle"],
         output: "", success: true)
@@ -311,7 +299,7 @@ class BundleInstallFromSourceTest < Minitest::Test
 
       tmpdir << "work/bundle/ruby/3.4.0/" << ["work/.bundle/config", "BUNDLE_PATH: bundle"]
 
-      capture_io { Kompo::BundleInstall.run }
+      capture_io { Kompo::BundleInstall.run(args: {cache_dir: File.join(tmpdir, ".kompo", "cache"), no_cache: true}) }
 
       refute @mock.called?(:capture, ruby_path, "-e", "require 'bundler'; puts Bundler::VERSION"),
         "Should not check bundler version when BUNDLED WITH is empty"
@@ -336,8 +324,6 @@ class BundleInstallFromSourceTest < Minitest::Test
         bundler_path: bundler_path,
         ruby_version: "3.4.1",
         ruby_major_minor: "3.4")
-      mock_args(cache_dir: cache_dir, no_cache: true)
-
       # Mock bundler config set command
       @mock.stub([ruby_path, bundler_path, "config", "set", "--local", "path", "bundle"],
         output: "", success: true)
@@ -353,7 +339,7 @@ class BundleInstallFromSourceTest < Minitest::Test
       # Create expected directory structure that bundle install would create
       tmpdir << "work/bundle/ruby/3.4.0/" << ["work/.bundle/config", "BUNDLE_PATH: bundle"]
 
-      capture_io { Kompo::BundleInstall.run }
+      capture_io { Kompo::BundleInstall.run(args: {cache_dir: cache_dir, no_cache: true}) }
 
       # Verify bundle install was called
       assert @mock.called?(:run, ruby_path, bundler_path, "install")

--- a/test/tasks/check_stdlibs_test.rb
+++ b/test/tasks/check_stdlibs_test.rb
@@ -22,9 +22,8 @@ class CheckStdlibsTest < Minitest::Test
     with_tmpdir do |tmpdir|
       tmpdir << "lib/ruby/3.4.0/"
       mock_install_ruby_with_dir(tmpdir)
-      mock_args(no_stdlib: true)
 
-      paths = Kompo::CheckStdlibs.paths
+      paths = Kompo::CheckStdlibs.paths(args: {no_stdlib: true})
 
       assert_equal [], paths
     end

--- a/test/tasks/collect_dependencies_test.rb
+++ b/test/tasks/collect_dependencies_test.rb
@@ -25,9 +25,7 @@ class CollectDependenciesTest < Minitest::Test
       mock_task(Kompo::MakeFsC, path: File.join(work_dir, "fs.c"))
       mock_task(Kompo::BuildNativeGem, exts_dir: nil, exts: [])
       mock_task(Kompo::InstallDeps, lib_paths: "", static_libs: [])
-      mock_args(project_dir: project_dir, output_dir: output_dir)
-
-      output_path = Kompo::CollectDependencies.output_path
+      output_path = Kompo::CollectDependencies.output_path(args: {project_dir: project_dir, output_dir: output_dir})
 
       # Output should be in output_dir with project name
       assert_equal File.join(output_dir, "myproject"), output_path
@@ -52,9 +50,7 @@ class CollectDependenciesTest < Minitest::Test
       mock_task(Kompo::MakeFsC, path: File.join(work_dir, "fs.c"))
       mock_task(Kompo::BuildNativeGem, exts_dir: nil, exts: [])
       mock_task(Kompo::InstallDeps, lib_paths: "", static_libs: [])
-      mock_args(project_dir: project_dir, output_dir: output_file)
-
-      output_path = Kompo::CollectDependencies.output_path
+      output_path = Kompo::CollectDependencies.output_path(args: {project_dir: project_dir, output_dir: output_file})
 
       # Output should be the specified file path
       assert_equal output_file, output_path
@@ -79,10 +75,8 @@ class CollectDependenciesTest < Minitest::Test
       mock_task(Kompo::MakeFsC, path: "/test/fs.c")
       mock_task(Kompo::BuildNativeGem, exts_dir: "/test/exts", exts: ["ext1"])
       mock_task(Kompo::InstallDeps, lib_paths: "", static_libs: [])
-      mock_args(project_dir: project_dir, output_dir: output_dir)
-
       # Access deps through exported value
-      deps = Kompo::CollectDependencies.deps
+      deps = Kompo::CollectDependencies.deps(args: {project_dir: project_dir, output_dir: output_dir})
 
       # Verify all dependencies were collected
       assert_equal "/test/install", deps.ruby_install_dir

--- a/test/tasks/copy_files_test.rb
+++ b/test/tasks/copy_files_test.rb
@@ -12,9 +12,8 @@ class CopyGemfileTest < Minitest::Test
       # No Gemfile in project_dir
 
       mock_task(Kompo::WorkDir, path: File.join(tmpdir, "work"), original_dir: tmpdir)
-      mock_args(project_dir: File.join(tmpdir, "project"))
 
-      refute Kompo::CopyGemfile.gemfile_exists
+      refute Kompo::CopyGemfile.gemfile_exists(args: {project_dir: File.join(tmpdir, "project")})
     end
   end
 
@@ -24,9 +23,8 @@ class CopyGemfileTest < Minitest::Test
 
       work_dir = File.join(tmpdir, "work")
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
-      mock_args(project_dir: File.join(tmpdir, "project"))
 
-      assert Kompo::CopyGemfile.gemfile_exists
+      assert Kompo::CopyGemfile.gemfile_exists(args: {project_dir: File.join(tmpdir, "project")})
       # Verify Gemfile was copied to work_dir
       assert File.exist?(File.join(work_dir, "Gemfile"))
     end
@@ -40,9 +38,8 @@ class CopyGemfileTest < Minitest::Test
 
       work_dir = File.join(tmpdir, "work")
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
-      mock_args(project_dir: File.join(tmpdir, "project"))
 
-      assert Kompo::CopyGemfile.gemfile_exists
+      assert Kompo::CopyGemfile.gemfile_exists(args: {project_dir: File.join(tmpdir, "project")})
       # Verify both files were copied to work_dir
       assert File.exist?(File.join(work_dir, "Gemfile"))
       assert File.exist?(File.join(work_dir, "Gemfile.lock"))
@@ -57,9 +54,8 @@ class CopyGemfileTest < Minitest::Test
 
       work_dir = File.join(tmpdir, "work")
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
-      mock_args(project_dir: File.join(tmpdir, "project"))
 
-      assert Kompo::CopyGemfile.gemfile_exists
+      assert Kompo::CopyGemfile.gemfile_exists(args: {project_dir: File.join(tmpdir, "project")})
       # Verify Gemfile and gemspec were copied to work_dir
       assert File.exist?(File.join(work_dir, "Gemfile"))
       assert File.exist?(File.join(work_dir, "my_gem.gemspec"))
@@ -74,9 +70,8 @@ class CopyGemfileTest < Minitest::Test
 
       work_dir = File.join(tmpdir, "work")
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
-      mock_args(project_dir: File.join(tmpdir, "project"))
 
-      assert Kompo::CopyGemfile.gemfile_exists
+      assert Kompo::CopyGemfile.gemfile_exists(args: {project_dir: File.join(tmpdir, "project")})
       # Verify Gemfile was copied but gemspec was not
       assert File.exist?(File.join(work_dir, "Gemfile"))
       refute File.exist?(File.join(work_dir, "my_gem.gemspec"))
@@ -92,9 +87,8 @@ class CopyGemfileTest < Minitest::Test
 
       work_dir = File.join(tmpdir, "work")
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
-      mock_args(project_dir: File.join(tmpdir, "project"))
 
-      assert Kompo::CopyGemfile.gemfile_exists
+      assert Kompo::CopyGemfile.gemfile_exists(args: {project_dir: File.join(tmpdir, "project")})
       # Verify all gemspecs were copied
       assert File.exist?(File.join(work_dir, "my_gem.gemspec"))
       assert File.exist?(File.join(work_dir, "other_gem.gemspec"))
@@ -113,10 +107,9 @@ class CopyGemfileTest < Minitest::Test
 
       work_dir = File.join(tmpdir, "work")
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
-      mock_args(project_dir: File.join(tmpdir, "project"))
 
       _out, err = capture_io do
-        refute Kompo::CopyGemfile.gemfile_exists
+        refute Kompo::CopyGemfile.gemfile_exists(args: {project_dir: File.join(tmpdir, "project")})
       end
 
       assert_match(/escap.*project directory/i, err)
@@ -130,10 +123,10 @@ class CopyGemfileTest < Minitest::Test
 
       work_dir = File.join(tmpdir, "work")
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
-      mock_args(project_dir: File.join(tmpdir, "project"), no_gemfile: true)
 
+      args = {project_dir: File.join(tmpdir, "project"), no_gemfile: true}
       # gemfile_exists should be false even though Gemfile exists
-      refute Kompo::CopyGemfile.gemfile_exists
+      refute Kompo::CopyGemfile.gemfile_exists(args: args)
       # Verify Gemfile was NOT copied to work_dir
       refute File.exist?(File.join(work_dir, "Gemfile"))
     end
@@ -151,10 +144,10 @@ class CopyProjectFilesTest < Minitest::Test
       work_dir = File.join(tmpdir, "work")
       project_dir = File.join(tmpdir, "project")
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
-      mock_args(project_dir: project_dir, entrypoint: "main.rb", files: [])
 
-      entrypoint_path = Kompo::CopyProjectFiles.entrypoint_path
-      additional_paths = Kompo::CopyProjectFiles.additional_paths
+      args = {project_dir: project_dir, entrypoint: "main.rb", files: []}
+      entrypoint_path = Kompo::CopyProjectFiles.entrypoint_path(args: args)
+      additional_paths = Kompo::CopyProjectFiles.additional_paths(args: args)
 
       assert_equal File.join(work_dir, "main.rb"), entrypoint_path
       assert_equal [], additional_paths
@@ -173,10 +166,10 @@ class CopyProjectFilesTest < Minitest::Test
       work_dir = File.join(tmpdir, "work")
       project_dir = File.join(tmpdir, "project")
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
-      mock_args(project_dir: project_dir, entrypoint: "main.rb", files: ["lib"])
 
-      entrypoint_path = Kompo::CopyProjectFiles.entrypoint_path
-      additional_paths = Kompo::CopyProjectFiles.additional_paths
+      args = {project_dir: project_dir, entrypoint: "main.rb", files: ["lib"]}
+      entrypoint_path = Kompo::CopyProjectFiles.entrypoint_path(args: args)
+      additional_paths = Kompo::CopyProjectFiles.additional_paths(args: args)
 
       assert_equal File.join(work_dir, "main.rb"), entrypoint_path
       assert_includes additional_paths, File.join(work_dir, "lib")
@@ -194,10 +187,10 @@ class CopyProjectFilesTest < Minitest::Test
       work_dir = File.join(tmpdir, "work")
       project_dir = File.join(tmpdir, "project")
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
-      mock_args(project_dir: project_dir, entrypoint: "main.rb", files: ["config/settings.rb"])
 
-      entrypoint_path = Kompo::CopyProjectFiles.entrypoint_path
-      additional_paths = Kompo::CopyProjectFiles.additional_paths
+      args = {project_dir: project_dir, entrypoint: "main.rb", files: ["config/settings.rb"]}
+      entrypoint_path = Kompo::CopyProjectFiles.entrypoint_path(args: args)
+      additional_paths = Kompo::CopyProjectFiles.additional_paths(args: args)
 
       assert_equal File.join(work_dir, "main.rb"), entrypoint_path
       assert_includes additional_paths, File.join(work_dir, "config/settings.rb")
@@ -216,9 +209,9 @@ class CopyProjectFilesTest < Minitest::Test
       work_dir = File.join(tmpdir, "work")
       project_dir = File.join(tmpdir, "project")
       mock_task(Kompo::WorkDir, path: work_dir, original_dir: tmpdir)
-      mock_args(project_dir: project_dir, entrypoint: "main.rb", files: ["."])
 
-      Kompo::CopyProjectFiles.entrypoint_path
+      args = {project_dir: project_dir, entrypoint: "main.rb", files: ["."]}
+      Kompo::CopyProjectFiles.entrypoint_path(args: args)
 
       # Verify all files were copied directly to work_dir (not into work_dir/project/)
       assert File.exist?(File.join(work_dir, "main.rb"))

--- a/test/tasks/kompo_vfs_path_test.rb
+++ b/test/tasks/kompo_vfs_path_test.rb
@@ -6,17 +6,6 @@ class KompoVfsPathTest < Minitest::Test
   include Taski::TestHelper::Minitest
   include TaskTestHelpers
 
-  def test_kompo_vfs_path_impl_can_access_local_path_arg
-    with_tmpdir do |tmpdir|
-      tmpdir << "kompo-vfs/"
-      vfs_path = File.join(tmpdir, "kompo-vfs")
-
-      mock_args(local_kompo_vfs_path: vfs_path)
-
-      assert_equal vfs_path, Taski.args[:local_kompo_vfs_path]
-    end
-  end
-
   def test_kompo_vfs_path_is_task
     assert Kompo::KompoVfsPath < Taski::Task
     assert_includes Kompo::KompoVfsPath.exported_methods, :path

--- a/test/tasks/make_c_test.rb
+++ b/test/tasks/make_c_test.rb
@@ -142,9 +142,8 @@ class MakeFsCTest < Minitest::Test
       project_dir = File.join(tmpdir, "project")
 
       mock_fs_c_dependencies(work_dir, tmpdir, entrypoint)
-      mock_args(project_dir: project_dir)
 
-      path = Kompo::MakeFsC.path
+      path = Kompo::MakeFsC.path(args: {project_dir: project_dir})
 
       assert File.exist?(path)
     end
@@ -159,9 +158,8 @@ class MakeFsCTest < Minitest::Test
       project_dir = File.join(tmpdir, "project")
 
       mock_fs_c_dependencies(work_dir, tmpdir, entrypoint)
-      mock_args(project_dir: project_dir)
 
-      path = Kompo::MakeFsC.path
+      path = Kompo::MakeFsC.path(args: {project_dir: project_dir})
       path_list = decode_embedded_paths(File.read(path))
       refute path_list.any? { |p| p.include?("debug.log") }
       refute path_list.any? { |p| p.include?("cache.txt") }
@@ -291,8 +289,7 @@ class MakeFsCTest < Minitest::Test
     with_tmpdir do |tmpdir|
       work_dir, entrypoint = setup_work_dir_with_entrypoint(tmpdir)
       mock_fs_c_dependencies(work_dir, tmpdir, entrypoint)
-      mock_args(compress: false)
-      path = Kompo::MakeFsC.path
+      path = Kompo::MakeFsC.path(args: {compress: false})
 
       assert File.exist?(path)
       content = File.read(path)
@@ -310,9 +307,8 @@ class MakeFsCTest < Minitest::Test
     with_tmpdir do |tmpdir|
       work_dir, entrypoint = setup_work_dir_with_entrypoint(tmpdir)
       mock_fs_c_dependencies(work_dir, tmpdir, entrypoint)
-      mock_args(compress: true)
 
-      path = Kompo::MakeFsC.path
+      path = Kompo::MakeFsC.path(args: {compress: true})
 
       assert File.exist?(path)
       content = File.read(path)
@@ -336,9 +332,8 @@ class MakeFsCTest < Minitest::Test
       lib_dir = File.join(work_dir, "lib")
 
       mock_fs_c_dependencies(work_dir, tmpdir, entrypoint, additional_paths: [lib_dir])
-      mock_args(compress: true)
 
-      path = Kompo::MakeFsC.path
+      path = Kompo::MakeFsC.path(args: {compress: true})
 
       assert File.exist?(path)
       content = File.read(path)
@@ -365,9 +360,8 @@ class MakeFsCTest < Minitest::Test
     with_tmpdir do |tmpdir|
       work_dir, entrypoint = setup_work_dir_with_entrypoint(tmpdir, content: "TEST_CONTENT_FOR_DECOMPRESSION")
       mock_fs_c_dependencies(work_dir, tmpdir, entrypoint)
-      mock_args(compress: true)
 
-      path = Kompo::MakeFsC.path
+      path = Kompo::MakeFsC.path(args: {compress: true})
       content = File.read(path)
 
       # Extract COMPRESSED_FILES data

--- a/test/tasks/make_main_c_test.rb
+++ b/test/tasks/make_main_c_test.rb
@@ -15,9 +15,8 @@ class MakeMainCTest < Minitest::Test
       mock_task(Kompo::CopyProjectFiles, entrypoint_path: 'path\to\main.rb')
       mock_task(Kompo::BuildNativeGem, exts: [])
       mock_task(Kompo::CopyGemfile, gemfile_exists: false)
-      mock_args(project_dir: File.join(tmpdir, "project"))
 
-      Kompo::MakeMainC.run
+      Kompo::MakeMainC.run(args: {project_dir: File.join(tmpdir, "project")})
       content = File.read(File.join(work_dir, "main.c"))
 
       assert_includes content, 'path\\\\to\\\\main.rb'
@@ -35,9 +34,8 @@ class MakeMainCTest < Minitest::Test
       mock_task(Kompo::CopyProjectFiles, entrypoint_path: "/tmp/main.rb")
       mock_task(Kompo::BuildNativeGem, exts: [])
       mock_task(Kompo::CopyGemfile, gemfile_exists: false)
-      mock_args(project_dir: project_dir)
 
-      Kompo::MakeMainC.run
+      Kompo::MakeMainC.run(args: {project_dir: project_dir})
       content = File.read(File.join(work_dir, "main.c"))
 
       assert_includes content, 'project \\"app\\"'
@@ -53,9 +51,8 @@ class MakeMainCTest < Minitest::Test
       mock_task(Kompo::CopyProjectFiles, entrypoint_path: "cle\0an.rb")
       mock_task(Kompo::BuildNativeGem, exts: [])
       mock_task(Kompo::CopyGemfile, gemfile_exists: false)
-      mock_args(project_dir: File.join(tmpdir, "project"))
 
-      Kompo::MakeMainC.run
+      Kompo::MakeMainC.run(args: {project_dir: File.join(tmpdir, "project")})
       content = File.read(File.join(work_dir, "main.c"))
 
       assert_includes content, "clean.rb"
@@ -72,9 +69,8 @@ class MakeMainCTest < Minitest::Test
       mock_task(Kompo::CopyProjectFiles, entrypoint_path: "/tmp/kompo-work/main.rb")
       mock_task(Kompo::BuildNativeGem, exts: [])
       mock_task(Kompo::CopyGemfile, gemfile_exists: false)
-      mock_args(project_dir: File.join(tmpdir, "project"))
 
-      Kompo::MakeMainC.run
+      Kompo::MakeMainC.run(args: {project_dir: File.join(tmpdir, "project")})
       content = File.read(File.join(work_dir, "main.c"))
 
       assert_includes content, "/tmp/kompo-work/main.rb"
@@ -90,9 +86,8 @@ class MakeMainCTest < Minitest::Test
       mock_task(Kompo::CopyProjectFiles, entrypoint_path: "/tmp/main.rb")
       mock_task(Kompo::BuildNativeGem, exts: [['path"evil', "Init_evil"]])
       mock_task(Kompo::CopyGemfile, gemfile_exists: false)
-      mock_args(project_dir: File.join(tmpdir, "project"))
 
-      Kompo::MakeMainC.run
+      Kompo::MakeMainC.run(args: {project_dir: File.join(tmpdir, "project")})
       content = File.read(File.join(work_dir, "main.c"))
 
       assert_includes content, 'path\\"evil'
@@ -109,9 +104,8 @@ class MakeMainCTest < Minitest::Test
       mock_task(Kompo::CopyProjectFiles, entrypoint_path: "line1\nline2\ttab\rret")
       mock_task(Kompo::BuildNativeGem, exts: [])
       mock_task(Kompo::CopyGemfile, gemfile_exists: false)
-      mock_args(project_dir: File.join(tmpdir, "project"))
 
-      Kompo::MakeMainC.run
+      Kompo::MakeMainC.run(args: {project_dir: File.join(tmpdir, "project")})
       content = File.read(File.join(work_dir, "main.c"))
 
       assert_includes content, "line1\\nline2\\ttab\\rret"

--- a/test/tasks/native_extensions_test.rb
+++ b/test/tasks/native_extensions_test.rb
@@ -76,9 +76,8 @@ class FindNativeExtensionsTest < Minitest::Test
              << ["#{bundled_ext_prefix}/bigdecimal.o", ""]
 
       mock_extension_tasks(ruby_install_dir, ruby_build_path, bundle_dir)
-      mock_args(no_stdlib: true)
 
-      extensions = Kompo::FindNativeExtensions.extensions
+      extensions = Kompo::FindNativeExtensions.extensions(args: {no_stdlib: true})
 
       bundled_ext = extensions.find { |e| e[:gem_ext_name] == "bigdecimal" }
       assert_nil bundled_ext, "Expected bundled gems to be skipped with --no-stdlib"
@@ -229,9 +228,7 @@ class BuildNativeGemWithMockTest < Minitest::Test
           is_prebuilt: true
         }
       ])
-      mock_args(no_cache: true)
-
-      capture_io { Kompo::BuildNativeGem.run }
+      capture_io { Kompo::BuildNativeGem.run(args: {no_cache: true}) }
 
       # Verify no extconf.rb or make commands were called for prebuilt extensions
       refute @mock.called?(:capture_all, "ruby", "extconf.rb")
@@ -270,14 +267,12 @@ class BuildNativeGemWithMockTest < Minitest::Test
           is_prebuilt: false
         }
       ])
-      mock_args(no_cache: true)
-
       # Create Makefile and .o files to simulate build
       tmpdir << ["ext/testgem/Makefile", makefile_content] \
              << ["ext/testgem/testgem.o", "fake object"] \
              << ["ext/testgem/helper.o", "fake object"]
 
-      capture_io { Kompo::BuildNativeGem.run }
+      capture_io { Kompo::BuildNativeGem.run(args: {no_cache: true}) }
 
       assert @mock.called?(:capture_all, "ruby", "extconf.rb")
       assert @mock.called?(:capture_all, "make", "-C", ext_dir)
@@ -316,9 +311,7 @@ class BuildNativeGemWithMockTest < Minitest::Test
           cargo_toml: cargo_toml
         }
       ])
-      mock_args(no_cache: true)
-
-      capture_io { Kompo::BuildNativeGem.run }
+      capture_io { Kompo::BuildNativeGem.run(args: {no_cache: true}) }
 
       assert @mock.called?(:run, "/usr/local/bin/cargo", "rustc", "--release")
     end

--- a/test/tasks/packing_test.rb
+++ b/test/tasks/packing_test.rb
@@ -71,15 +71,13 @@ class PackingForMacOSDryRunTest < Minitest::Test
         enc_files: [],
         output_path: output_path)
 
-      mock_args(dry_run: true)
-
       # Mock pkg-config calls
       @mock.stub(["pkg-config", "--cflags", "#{ruby_install_dir}/lib/pkgconfig/ruby.pc"],
         output: "-I#{ruby_install_dir}/include")
       @mock.stub(["pkg-config", "--variable=MAINLIBS", "#{ruby_install_dir}/lib/pkgconfig/ruby.pc"],
         output: "-lpthread -lm")
 
-      capture_io { Kompo::Packing.run }
+      capture_io { Kompo::Packing.run(args: {dry_run: true}) }
 
       # Verify clang was NOT actually called (dry_run skips execution)
       refute @mock.called?(:run, "clang"), "clang should not be executed in dry_run mode"
@@ -143,15 +141,13 @@ class PackingForLinuxDryRunTest < Minitest::Test
         enc_files: [],
         output_path: output_path)
 
-      mock_args(dry_run: true)
-
       # Mock pkg-config calls
       @mock.stub(["pkg-config", "--cflags", "#{ruby_install_dir}/lib/pkgconfig/ruby.pc"],
         output: "-I#{ruby_install_dir}/include")
       @mock.stub(["pkg-config", "--variable=MAINLIBS", "#{ruby_install_dir}/lib/pkgconfig/ruby.pc"],
         output: "-lz -lgmp -lpthread -ldl -lm")
 
-      stdout, = capture_io { Kompo::Packing.run }
+      stdout, = capture_io { Kompo::Packing.run(args: {dry_run: true}) }
 
       # Verify gcc was NOT actually called (dry_run skips execution)
       refute @mock.called?(:run, "gcc"), "gcc should not be executed in dry_run mode"

--- a/test/tasks/work_dir_test.rb
+++ b/test/tasks/work_dir_test.rb
@@ -9,11 +9,10 @@ class WorkDirTest < Minitest::Test
 
   def test_work_dir_creates_temp_directory
     with_tmpdir do |tmpdir|
-      # Mock Taski.args to use our temp directory for cache
-      mock_args(kompo_cache: File.join(tmpdir, ".kompo", "cache"))
+      args = {kompo_cache: File.join(tmpdir, ".kompo", "cache")}
 
-      path = Kompo::WorkDir.path
-      original_dir = Kompo::WorkDir.original_dir
+      path = Kompo::WorkDir.path(args: args)
+      original_dir = Kompo::WorkDir.original_dir(args: args)
 
       assert path
       assert Dir.exist?(path)
@@ -32,9 +31,7 @@ class WorkDirTest < Minitest::Test
              << ["cached_work/#{Kompo::WorkDir::MARKER_FILE}", "kompo-work-dir"] \
              << [".kompo/cache/#{RUBY_VERSION}/metadata.json", JSON.generate(metadata)]
 
-      mock_args(kompo_cache: File.join(tmpdir, ".kompo", "cache"))
-
-      path = Kompo::WorkDir.path
+      path = Kompo::WorkDir.path(args: {kompo_cache: File.join(tmpdir, ".kompo", "cache")})
 
       assert_equal cached_work_dir, path
     end
@@ -44,10 +41,8 @@ class WorkDirTest < Minitest::Test
     with_tmpdir do |tmpdir|
       tmpdir << [".kompo/cache/#{RUBY_VERSION}/metadata.json", "not valid json"]
 
-      mock_args(kompo_cache: File.join(tmpdir, ".kompo", "cache"))
-
       # Should fallback to creating new work_dir
-      path = Kompo::WorkDir.path
+      path = Kompo::WorkDir.path(args: {kompo_cache: File.join(tmpdir, ".kompo", "cache")})
 
       assert path
       assert Dir.exist?(path)
@@ -65,9 +60,7 @@ class WorkDirTest < Minitest::Test
       # Verify the directory doesn't exist
       refute Dir.exist?(cached_work_dir)
 
-      mock_args(kompo_cache: File.join(tmpdir, ".kompo", "cache"))
-
-      path = Kompo::WorkDir.path
+      path = Kompo::WorkDir.path(args: {kompo_cache: File.join(tmpdir, ".kompo", "cache")})
 
       # Should recreate the cached work_dir path
       assert_equal cached_work_dir, path
@@ -86,11 +79,9 @@ class WorkDirTest < Minitest::Test
       tmpdir << "foreign_directory/" \
              << [".kompo/cache/#{RUBY_VERSION}/metadata.json", JSON.generate(metadata)]
 
-      mock_args(kompo_cache: File.join(tmpdir, ".kompo", "cache"))
-
       # Capture stderr to verify warning
       _out, err = capture_io do
-        path = Kompo::WorkDir.path
+        path = Kompo::WorkDir.path(args: {kompo_cache: File.join(tmpdir, ".kompo", "cache")})
         # Should NOT use the foreign directory, should create a new one
         refute_equal cached_work_dir, path
         assert Dir.exist?(path)
@@ -107,10 +98,8 @@ class WorkDirTest < Minitest::Test
       metadata = {"work_dir" => cached_work_dir, "ruby_version" => RUBY_VERSION}
       tmpdir << [".kompo/cache/#{RUBY_VERSION}/metadata.json", JSON.generate(metadata)]
 
-      mock_args(kompo_cache: File.join(tmpdir, ".kompo", "cache"))
-
       _out, err = capture_io do
-        path = Kompo::WorkDir.path
+        path = Kompo::WorkDir.path(args: {kompo_cache: File.join(tmpdir, ".kompo", "cache")})
 
         refute_equal cached_work_dir, path
         assert Dir.exist?(path)
@@ -128,10 +117,8 @@ class WorkDirTest < Minitest::Test
 
       tmpdir << [".kompo/cache/#{RUBY_VERSION}/metadata.json", JSON.generate(metadata)]
 
-      mock_args(kompo_cache: File.join(tmpdir, ".kompo", "cache"))
-
       _out, err = capture_io do
-        path = Kompo::WorkDir.path
+        path = Kompo::WorkDir.path(args: {kompo_cache: File.join(tmpdir, ".kompo", "cache")})
 
         refute_equal cached_work_dir, path
         assert Dir.exist?(path)
@@ -151,10 +138,8 @@ class WorkDirTest < Minitest::Test
 
       tmpdir << [".kompo/cache/#{RUBY_VERSION}/metadata.json", JSON.generate(metadata)]
 
-      mock_args(kompo_cache: File.join(tmpdir, ".kompo", "cache"))
-
       _out, err = capture_io do
-        path = Kompo::WorkDir.path
+        path = Kompo::WorkDir.path(args: {kompo_cache: File.join(tmpdir, ".kompo", "cache")})
 
         refute_equal cached_work_dir, path
         assert Dir.exist?(path)
@@ -175,9 +160,7 @@ class WorkDirTest < Minitest::Test
              << [".kompo/cache/#{RUBY_VERSION}/metadata.json", JSON.generate(metadata)]
 
       # Set no_cache option
-      mock_args(kompo_cache: File.join(tmpdir, ".kompo", "cache"), no_cache: true)
-
-      path = Kompo::WorkDir.path
+      path = Kompo::WorkDir.path(args: {kompo_cache: File.join(tmpdir, ".kompo", "cache"), no_cache: true})
 
       # Should NOT use cached work_dir, should create a new one
       refute_equal cached_work_dir, path


### PR DESCRIPTION
## Summary
- Remove all `mock_args` usage from tests, replacing with `args:` parameter passed directly to task class methods (`Task.value(args:)`, `Task.exported_method(args:)`)
- Decouple `CommandRunner` from `Taski.args` by adding configurable `verbose`/`dry_run` attributes
- Set `CommandRunner` options from CLI args in `exe/kompo`

## Test plan
- [x] All 340 tests pass with 0 failures
- [x] standardrb lint passes
- [ ] Verify dry-run and verbose modes work correctly via CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified argument-passing to use an explicit args hash across commands.
  * Global propagation of verbose and dry-run options so CLI verbosity and dry-run behavior apply consistently.

* **Tests**
  * Test suite updated to use global setup/teardown for verbose/dry-run and the new args-style interfaces.

* **Chore**
  * Updated task runner dependency version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->