### PR TITLE
Require kompo-vfs 0.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           fi
           cd ../kompo-vfs
           git fetch origin
-          git checkout v0.6.0
+          git checkout v0.7.0
 
       - name: Build kompo-vfs
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Require kompo-vfs >= 0.7.0. This is also the version fetched by the prebuilt-binary
+  installer and built from source in CI, so existing 0.6.x installations must be upgraded
+  (`brew upgrade kompo-vfs`, or `git pull && cargo build --release` in `~/.kompo/kompo-vfs`)
+
 ## [0.4.0] - 2025-01-26
 
 ### Added

--- a/lib/kompo/version.rb
+++ b/lib/kompo/version.rb
@@ -2,5 +2,5 @@
 
 module Kompo
   VERSION = "0.4.0"
-  KOMPO_VFS_MIN_VERSION = "0.6.0"
+  KOMPO_VFS_MIN_VERSION = "0.7.0"
 end

--- a/test/tasks/kompo_vfs_path_test.rb
+++ b/test/tasks/kompo_vfs_path_test.rb
@@ -37,7 +37,7 @@ class KompoVfsPathTest < Minitest::Test
 
   def test_kompo_vfs_version_check_passes_when_version_satisfies
     with_tmpdir do |tmpdir|
-      tmpdir << ["KOMPO_VFS_VERSION", "0.6.0"]
+      tmpdir << ["KOMPO_VFS_VERSION", "0.7.0"]
       # Should not raise
       Kompo::KompoVfsVersionCheck.verify!(tmpdir)
     end
@@ -53,12 +53,13 @@ class KompoVfsPathTest < Minitest::Test
 
   def test_kompo_vfs_version_check_fails_when_version_too_old
     with_tmpdir do |tmpdir|
-      tmpdir << ["KOMPO_VFS_VERSION", "0.5.1"]
+      # 0.6.0 was the previous minimum, so this also pins that the bar moved
+      tmpdir << ["KOMPO_VFS_VERSION", "0.6.0"]
       error = assert_raises(Kompo::KompoVfsVersionCheck::IncompatibleVersionError) do
         Kompo::KompoVfsVersionCheck.verify!(tmpdir)
       end
-      assert_includes error.message, "0.5.1 is too old"
-      assert_includes error.message, "Required: >= 0.6.0"
+      assert_includes error.message, "0.6.0 is too old"
+      assert_includes error.message, "Required: >= 0.7.0"
     end
   end
 
@@ -142,7 +143,7 @@ class KompoVfsPathFromHomebrewInstalledTest < Minitest::Test
     with_tmpdir do |tmpdir|
       tmpdir << ["lib/libkompo_fs.a", "fake lib"] \
              << ["lib/libkompo_wrap.a", "fake lib"] \
-             << ["lib/KOMPO_VFS_VERSION", "0.6.0"]
+             << ["lib/KOMPO_VFS_VERSION", "0.7.0"]
 
       @mock.stub(["/opt/homebrew/bin/brew", "--prefix", "kompo-vfs"], output: tmpdir, success: true)
 
@@ -187,7 +188,7 @@ class KompoVfsPathFromHomebrewInstallWithMockTest < Minitest::Test
 
   def test_install_taps_and_installs
     with_tmpdir do |tmpdir|
-      tmpdir << ["lib/KOMPO_VFS_VERSION", "0.6.0"]
+      tmpdir << ["lib/KOMPO_VFS_VERSION", "0.7.0"]
 
       @mock.stub(["/opt/homebrew/bin/brew", "tap", "ahogappa/kompo-vfs", "https://github.com/ahogappa/kompo-vfs.git"], output: "", success: true)
       @mock.stub(["/opt/homebrew/bin/brew", "install", "ahogappa/kompo-vfs/kompo-vfs"], output: "", success: true)


### PR DESCRIPTION
Bumps the required kompo-vfs version from 0.6.0 to 0.7.0.

## Why this touches four places

`KOMPO_VFS_MIN_VERSION` is not only a floor. `kompo_vfs_path.rb` builds the release tarball URL and the install directory name from it, and CI checks out the same tag to build from source. Bumping it moves all three behaviours at once, so every site that pinned 0.6.0 has to move together.

| File | Change |
|---|---|
| `lib/kompo/version.rb` | `KOMPO_VFS_MIN_VERSION` → `0.7.0` |
| `.github/workflows/ci.yml` | tag checked out before `cargo build --release` → `v0.7.0` |
| `test/tasks/kompo_vfs_path_test.rb` | fixtures feeding `verify!`, which now raises on a `0.6.0` `KOMPO_VFS_VERSION` file |
| `CHANGELOG.md` | Unreleased entry noting 0.6.x installs must be upgraded |

---
_Generated by [Claude Code](https://claude.ai/code/session_012bpbZACT4YWiN8ucX6ZvyV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Updated the minimum supported Kompo VFS version to 0.7.0.
  * Older Kompo VFS versions, including 0.6.0, are no longer accepted.

* **Documentation**
  * Added upgrade guidance for Homebrew and source-built installations.
  * Updated the unreleased changelog with the new requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->